### PR TITLE
feat: 전역 예외 설정, JWT 토큰 생성, 기본적인 security 설정

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.rutina.rutinabackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // 인증 없이 접근 가능한 엔드포인트
+    private static final String[] PUBLIC_URLS = {
+            "/api/v1/auth/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/swagger-config",
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)                          // JWT 방식이므로 CSRF 불필요
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_URLS).permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(); // 단방향 해시, 레인보우 테이블 공격 방어
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/exception/BusinessException.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package com.rutina.rutinabackend.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String code;
+
+    public BusinessException(HttpStatus status, String code, String message) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.rutina.rutinabackend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 인증
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH_001", "이미 사용 중인 이메일입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_002", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_003", "존재하지 않는 사용자입니다."),
+
+    // 공통
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값이 올바르지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    // 사용 예: throw ErrorCode.USER_NOT_FOUND.toException();
+    public BusinessException toException() {
+        return new BusinessException(status, code, message);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.rutina.rutinabackend.global.exception;
+
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ApiResponse.fail(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        // 여러 필드 오류를 ", "로 합쳐서 반환
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT.getCode(), message));
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/rutina/rutinabackend/global/jwt/JwtProvider.java
@@ -1,0 +1,76 @@
+package com.rutina.rutinabackend.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiry}")
+    private long accessTokenExpiry;
+
+    @Value("${jwt.refresh-token-expiry}")
+    private long refreshTokenExpiry;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        // @Value 주입 완료 후 SecretKey 초기화
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId, String email) {
+        return buildToken(userId, email, accessTokenExpiry);
+    }
+
+    public String generateRefreshToken(Long userId, String email) {
+        return buildToken(userId, email, refreshTokenExpiry);
+    }
+
+    private String buildToken(Long userId, String email, long expiryMs) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiryMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims parseToken(String token) {
+        // 서명 검증 + 만료 여부 자동 체크
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean isValid(String token) {
+        try {
+            parseToken(token);
+            return true;
+        } catch (Exception e) {
+            return false; // 만료 또는 변조된 토큰
+        }
+    }
+
+    public Long getUserId(String token) {
+        return Long.valueOf(parseToken(token).getSubject());
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/response/ApiResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/global/response/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.rutina.rutinabackend.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 팩토리 메서드로만 생성
+@JsonInclude(JsonInclude.Include.NON_NULL)         // null 필드 JSON 제외
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, "SUCCESS_200", "데이터를 성공적으로 불러왔습니다.", data);
+    }
+
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(true, "SUCCESS_200", message, data);
+    }
+
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(true, "SUCCESS_201", message, data);
+    }
+
+    public static ApiResponse<Void> fail(String code, String message) {
+        return new ApiResponse<>(false, code, message, null);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,18 +2,28 @@ spring:
   application:
     name: rutina-backend
 
-# db 연결 안 해서 일단 다 비활성화 함.
   datasource:
-    url: ''
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 # ai 연결 안 해서 일단 임시값
   ai:
     openai:
       api-key: "dummy"
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiry: 1800000       # 30분
+  refresh-token-expiry: 604800000    # 7일


### PR DESCRIPTION
## 작업 내용

- Close #4 

### 글로벌 공통 모듈
- 공통 응답 형식 `ApiResponse` 구현
- 비즈니스 예외 클래스 및 에러 코드 정의 (`BusinessException`, `ErrorCode`)
- 전역 예외 핸들러 구현 (`GlobalExceptionHandler`)
- JWT 토큰 생성 및 검증 로직 구현 (`JwtProvider`)
- Spring Security 설정 (STATELESS, 공개 경로 허용)

### 환경 설정
- DB, JWT 환경변수 기반 설정
- Redis 비활성화 (추후 Refresh Token 저장 시 활성화 예정)
- Swagger 연동