### PR TITLE
[feat] 인증(Auth) 기능 구현 - 회원가입 / 로그인 / 토큰 재발급 / 로그아웃

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.domain.refreshToken.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/entity/RefreshToken.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/entity/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.rutina.rutinabackend.domain.refreshToken.entity;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "token_value", nullable = false, columnDefinition = "text")
+    private String tokenValue;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    public static RefreshToken of(User user, String tokenValue, long expiryMs) {
+        RefreshToken token = new RefreshToken();
+        token.user = user;
+        token.tokenValue = tokenValue;
+        token.expiresAt = OffsetDateTime.now().plusNanos(expiryMs * 1_000_000L);
+        token.createdAt = OffsetDateTime.now();
+        token.updatedAt = OffsetDateTime.now();
+        return token;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.rutina.rutinabackend.domain.refreshToken.repository;
+
+import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenValue(String tokenValue);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -40,6 +40,13 @@ public class AuthController {
         return ApiResponse.ok("토큰이 재발급되었습니다.", response);
     }
 
+    // 로그아웃
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@RequestBody @Valid TokenRefreshRequest request) {
+        authService.logout(request);
+        return ApiResponse.ok("로그아웃되었습니다.", null);
+    }
+
     // 이메일 중복 확인
     @GetMapping("/check-email")
     public ApiResponse<Map<String, Boolean>> checkEmail(@RequestParam String email) {

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -25,6 +25,13 @@ public class AuthController {
         return ApiResponse.created("회원가입이 완료되었습니다.", response);
     }
 
+    // 로컬 로그인
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ApiResponse.ok("로그인에 성공했습니다.", response);
+    }
+
     // 이메일 중복 확인
     @GetMapping("/check-email")
     public ApiResponse<Map<String, Boolean>> checkEmail(@RequestParam String email) {

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.rutina.rutinabackend.domain.user.controller;
+
+import com.rutina.rutinabackend.domain.user.dto.*;
+import com.rutina.rutinabackend.domain.user.service.AuthService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 로컬 회원가입
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
+        SignUpResponse response = authService.signUp(request);
+        return ApiResponse.created("회원가입이 완료되었습니다.", response);
+    }
+
+    // 이메일 중복 확인
+    @GetMapping("/check-email")
+    public ApiResponse<Map<String, Boolean>> checkEmail(@RequestParam String email) {
+        boolean isDuplicate = authService.checkEmailDuplicate(email);
+        return ApiResponse.ok(
+                isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다.",
+                Map.of("isDuplicate", isDuplicate)
+        );
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.rutina.rutinabackend.domain.user.controller;
 
+import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.user.service.AuthService;
 import com.rutina.rutinabackend.global.response.ApiResponse;
@@ -30,6 +31,13 @@ public class AuthController {
     public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ApiResponse.ok("로그인에 성공했습니다.", response);
+    }
+
+    // 토큰 재발급
+    @PostMapping("/reissue")
+    public ApiResponse<LoginResponse> reissue(@RequestBody @Valid TokenRefreshRequest request) {
+        LoginResponse response = authService.reissue(request);
+        return ApiResponse.ok("토큰이 재발급되었습니다.", response);
     }
 
     // 이메일 중복 확인

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password
+) {}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType
+) {
+    public static LoginResponse of(String accessToken, String refreshToken) {
+        return new LoginResponse(accessToken, refreshToken, "Bearer");
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/SignUpRequest.java
@@ -1,0 +1,20 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 20, message = "닉네임은 2~20자 사이여야 합니다.")
+        String nickname
+) {}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/SignUpResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/SignUpResponse.java
@@ -1,0 +1,13 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+
+public record SignUpResponse(
+        Long userId,
+        String email,
+        String nickname
+) {
+    public static SignUpResponse from(User user) {
+        return new SignUpResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -1,0 +1,64 @@
+package com.rutina.rutinabackend.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")   // soft delete - 조회 시 자동 필터링
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String age;
+
+    @Column(nullable = false)
+    private String role;
+
+    private Integer gender;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    // ── 일반 회원가입용 정적 팩토리 ──────────────────────────
+    public static User createLocal(String email, String encodedPassword, String nickname) {
+        User user = new User();
+        user.email = email;
+        user.password = encodedPassword;
+        user.nickname = nickname;
+        user.role = "USER";
+        user.provider = "LOCAL";
+        user.createdAt = OffsetDateTime.now();
+        user.updatedAt = OffsetDateTime.now();
+        return user;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.rutina.rutinabackend.domain.user.repository;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -1,9 +1,12 @@
 package com.rutina.rutinabackend.domain.user.service;
 
 import com.rutina.rutinabackend.domain.user.dto.*;
+import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
+import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,7 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     // ── 회원가입 ───────────────────────────────────────────
     @Transactional
@@ -32,6 +37,30 @@ public class AuthService {
         userRepository.save(user);
 
         return SignUpResponse.from(user);
+    }
+
+    // ── 로그인 ─────────────────────────────────────────────
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(ErrorCode.INVALID_CREDENTIALS::toException);
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw ErrorCode.INVALID_CREDENTIALS.toException();
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
+
+        // 기존 refresh token 삭제 후 신규 저장 (1인 1토큰)
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(
+                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry())
+        );
+
+        return LoginResponse.of(accessToken, refreshToken);
     }
 
     // ── 이메일 중복 확인 ─────────────────────────

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -1,8 +1,10 @@
 package com.rutina.rutinabackend.domain.user.service;
 
+import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import com.rutina.rutinabackend.domain.user.entity.User;
+import java.time.OffsetDateTime;
 import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
@@ -61,6 +63,40 @@ public class AuthService {
         );
 
         return LoginResponse.of(accessToken, refreshToken);
+    }
+
+    // ── 토큰 재발급 (refresh token rotation) ────────────────
+    @Transactional
+    public LoginResponse reissue(TokenRefreshRequest request) {
+
+        // JWT 서명·만료 검증
+        if (!jwtProvider.isValid(request.refreshToken())) {
+            throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
+        }
+
+        // DB에 저장된 토큰인지 확인
+        RefreshToken saved = refreshTokenRepository.findByTokenValue(request.refreshToken())
+                .orElseThrow(ErrorCode.INVALID_REFRESH_TOKEN::toException);
+
+        // DB expires_at 만료 검증
+        if (saved.getExpiresAt().isBefore(OffsetDateTime.now())) {
+            refreshTokenRepository.delete(saved);
+            throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
+        }
+
+        User user = saved.getUser();
+
+        // 새 토큰 발급 (rotation)
+        String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String newRefreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
+
+        // 기존 토큰 교체
+        refreshTokenRepository.delete(saved);
+        refreshTokenRepository.save(
+                RefreshToken.of(user, newRefreshToken, jwtProvider.getRefreshTokenExpiry())
+        );
+
+        return LoginResponse.of(newAccessToken, newRefreshToken);
     }
 
     // ── 이메일 중복 확인 ─────────────────────────

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.rutina.rutinabackend.domain.user.service;
+
+import com.rutina.rutinabackend.domain.user.dto.*;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // ── 회원가입 ───────────────────────────────────────────
+    @Transactional
+    public SignUpResponse signUp(SignUpRequest request) {
+
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.email())) {
+            throw ErrorCode.DUPLICATE_EMAIL.toException();
+        }
+
+        // 비밀번호 bcrypt 해시
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        User user = User.createLocal(request.email(), encodedPassword, request.nickname());
+        userRepository.save(user);
+
+        return SignUpResponse.from(user);
+    }
+
+    // ── 이메일 중복 확인 ─────────────────────────
+    @Transactional(readOnly = true)
+    public boolean checkEmailDuplicate(String email) {
+        return userRepository.existsByEmail(email);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -99,6 +99,13 @@ public class AuthService {
         return LoginResponse.of(newAccessToken, newRefreshToken);
     }
 
+    // ── 로그아웃 ──────────────────────────────────────────────
+    @Transactional
+    public void logout(TokenRefreshRequest request) {
+        refreshTokenRepository.findByTokenValue(request.refreshToken())
+                .ifPresent(refreshTokenRepository::delete);
+    }
+
     // ── 이메일 중복 확인 ─────────────────────────
     @Transactional(readOnly = true)
     public boolean checkEmailDuplicate(String email) {

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH_001", "이미 사용 중인 이메일입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_002", "이메일 또는 비밀번호가 올바르지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_003", "존재하지 않는 사용자입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "유효하지 않거나 만료된 리프레시 토큰입니다."),
 
     // 공통
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값이 올바르지 않습니다.");

--- a/src/main/java/com/rutina/rutinabackend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/rutina/rutinabackend/global/jwt/JwtProvider.java
@@ -73,4 +73,8 @@ public class JwtProvider {
     public Long getUserId(String token) {
         return Long.valueOf(parseToken(token).getSubject());
     }
+
+    public long getRefreshTokenExpiry() {
+        return refreshTokenExpiry;
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: rutina-backend
 
   datasource:
-    url: ${DB_URL}
+    url: ${DB_URL}?prepareThreshold=0
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #8 

##  작업 내용

엔티티 & 레포지토리
- `User`, `RefreshToken` 엔티티 구현
- `UserRepository`, `RefreshTokenRepository` 구현

회원가입
- 회원가입 DTO 구현
- 이메일 중복 확인 포함한 회원가입 로직 및 엔드포인트 구현

로그인
- 로그인 DTO 구현
- 로그인 로직 및 엔드포인트 구현

토큰 재발급
- 토큰 재발급 DTO 구현
- 토큰 재발급 로직 및 에러코드 추가
- 토큰 재발급 엔드포인트 구현

로그아웃
- 로그아웃 로직 및 엔드포인트 구현

## 기타

- Supabase 커넥션 풀러 `prepared statement` 충돌 해결  