### PR TITLE
[feat] 도메인 entity 및 repository 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/entity/AiLog.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/entity/AiLog.java
@@ -1,0 +1,57 @@
+package com.rutina.rutinabackend.domain.ailog.entity;
+
+import com.rutina.rutinabackend.domain.routine.entity.Routine;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ai_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id")
+    private Routine routine;
+
+    @Column(name = "request_type", nullable = false)
+    private String requestType;     // 요청 유형
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String prompt;      // AI에 전달된 프롬프트
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String response;        // AI 응답 내용
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    // ── AI 로그 생성용 정적 팩토리 ──────────────────────────
+    public static AiLog create(User loginUser, Routine routine, String requestType, String prompt, String response) {
+        AiLog aiLog = new AiLog();
+        aiLog.user = loginUser;
+        aiLog.routine = routine;
+        aiLog.requestType = requestType;
+        aiLog.prompt = prompt;
+        aiLog.response = response;
+        aiLog.createdAt = OffsetDateTime.now();
+        aiLog.updatedAt = OffsetDateTime.now();
+        return aiLog;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -1,0 +1,13 @@
+package com.rutina.rutinabackend.domain.ailog.repository;
+
+import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AiLogRepository extends JpaRepository<AiLog, Long> {
+    List<AiLog> findByUserId(Long userId);
+    List<AiLog> findByRoutineId(Long routineId);
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
@@ -1,0 +1,55 @@
+package com.rutina.rutinabackend.domain.category.entity;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long  id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "color_code", nullable = false)
+    private String colorCode;
+
+
+    @Column(name = "rt_sum", nullable = false)
+    private String rtSum;   // 카테고리 루틴 집계값
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;  // 정렬 순서
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    // ── 카테고리 생성용 정적 팩토리 ──────────────────────────
+    public static Category create(User user, String name, String colorCode, String rtSum, Integer sortOrder) {
+        Category category = new Category();
+        category.user = user;
+        category.name = name;
+        category.colorCode = colorCode;
+        category.rtSum = rtSum;
+        category.sortOrder = sortOrder;
+        category.createdAt = OffsetDateTime.now();
+        category.updatedAt = OffsetDateTime.now();
+        return category;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.rutina.rutinabackend.domain.category.repository;
+
+import com.rutina.rutinabackend.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByUserId(Long userId);
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/entity/DailyTarget.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/entity/DailyTarget.java
@@ -1,0 +1,48 @@
+package com.rutina.rutinabackend.domain.dailytarget.entity;
+
+import com.rutina.rutinabackend.domain.routine.entity.Routine;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "daily_targets")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyTarget {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id", nullable = false)
+    private Routine routine;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;       //목표 날짜
+
+    @Column(name = "is_completed", nullable = false)
+    private Boolean isCompleted;        //완료 여부
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    // ── 일일 목표 생성용 정적 팩토리 ──────────────────────────
+    public static DailyTarget create(Routine routine, LocalDate targetDate) {
+        DailyTarget dailyTarget = new DailyTarget();
+        dailyTarget.routine = routine;
+        dailyTarget.targetDate = targetDate;
+        dailyTarget.isCompleted = false;
+        dailyTarget.createdAt = OffsetDateTime.now();
+        dailyTarget.updatedAt = OffsetDateTime.now();
+        return dailyTarget;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
@@ -1,0 +1,14 @@
+package com.rutina.rutinabackend.domain.dailytarget.repository;
+
+import com.rutina.rutinabackend.domain.dailytarget.entity.DailyTarget;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface DailyTargetRepository extends JpaRepository<DailyTarget, Long> {
+    List<DailyTarget> findByRoutineId(Long routineId);
+    List<DailyTarget> findByRoutineIdAndTargetDate(Long routineId, LocalDate targetDate);
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/entity/Routine.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/entity/Routine.java
@@ -1,0 +1,71 @@
+package com.rutina.rutinabackend.domain.routine.entity;
+
+
+import com.rutina.rutinabackend.domain.category.entity.Category;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "routines")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class Routine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Boolean alarm;      //알람 사용 여부
+
+    @Column(nullable = false)
+    private Boolean state;      //루틴 활성 여부
+
+    @Column(name = "cron_expression")
+    private String cronExpression;      //반복  스케줄 표현식
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    // ── 루틴 생성용 정적 팩토리 ──────────────────────────
+    public static Routine create(User loginUser, Category category, String title, Boolean alarm, Boolean state, String cronExpression, LocalTime startTime, LocalTime endTime) {
+        Routine routine = new Routine();
+        routine.user = loginUser;
+        routine.category = category;
+        routine.title = title;
+        routine.alarm = alarm;
+        routine.state = state;
+        routine.cronExpression = cronExpression;
+        routine.startTime = startTime;
+        routine.endTime = endTime;
+        routine.createdAt = OffsetDateTime.now();
+        routine.updatedAt = OffsetDateTime.now();
+        return routine;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
@@ -1,0 +1,13 @@
+package com.rutina.rutinabackend.domain.routine.repository;
+
+import com.rutina.rutinabackend.domain.routine.entity.Routine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    List<Routine> findByUserId(Long userId);
+    List<Routine> findByUserIdAndCategoryId(Long userId, Long categoryId);
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #12

---

## 작업 내용

- `Category`, `Routine`, `DailyTarget`, `AiLog` entity 구현
- `CategoryRepository`, `RoutineRepository`, `DailyTargetRepository`, `AiLogRepository` 구현

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> entity 및 repository 구현 단계로 API 엔드포인트는 아직 없습니다.
> 파일별 커밋 분리 예정이었으나 stash 복구 과정에서 전체 파일이 
> 하나의 커밋으로 묶여 커밋 메시지가 1개입니다.