### PR TITLE
[feat] Gemini API 연동 - 요청, 응답 초안 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // ── AI ────────────────────────────────────────────────
-    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
 
     // ── 개발 생산성 ────────────────────────────────────────
     compileOnly    'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai' //제미나이 스타터로 설정
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
     // ── Test ──────────────────────────────────────────────
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.ai:spring-ai-bom:1.0.0'
+        mavenBom 'org.springframework.ai:spring-ai-bom:1.1.4'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai' //제미나이 스타터로 설정
 
     // ── Test ──────────────────────────────────────────────
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -1,0 +1,22 @@
+package com.rutina.rutinabackend.domain.ailog.controller;
+
+import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
+import com.rutina.rutinabackend.domain.ailog.service.AiService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class AiController {
+
+    private final AiService aiService;
+
+    @PostMapping("/generate")
+    public ApiResponse<AiResponse> generate(@RequestBody AiRequest request) {
+        AiResponse response = aiService.generate(request);
+        return ApiResponse.ok("AI 응답 생성에 성공했습니다.", response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiRequest(
+        Long userId,
+        Long routineId,
+        String question
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
@@ -2,7 +2,6 @@ package com.rutina.rutinabackend.domain.ailog.dto;
 
 public record AiRequest(
         Long userId,
-        Long routineId,
         String question
 ) {
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiResponse.java
@@ -1,0 +1,6 @@
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiResponse(
+        String response
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -2,36 +2,41 @@ package com.rutina.rutinabackend.domain.ailog.service;
 
 import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
 import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
-import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
-import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+//import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+//import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.BusinessException;
-import com.rutina.rutinabackend.global.exception.ErrorCode;
+//import com.rutina.rutinabackend.global.exception.ErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 
 @Service
 public class AiService {
 
     private final ChatClient chatClient;
     private final UserRepository userRepository;
-    private final AiLogRepository aiLogRepository;
+//    private final AiLogRepository aiLogRepository;
 
     public AiService(
             ChatClient.Builder chatClientBuilder,
-            UserRepository userRepository,
-            AiLogRepository aiLogRepository
+            UserRepository userRepository
+//            AiLogRepository aiLogRepository
     ) {
         this.chatClient = chatClientBuilder.build();
         this.userRepository = userRepository;
-        this.aiLogRepository = aiLogRepository;
+//        this.aiLogRepository = aiLogRepository;
     }
 
     //간단하게 임시 프롬포트 작성해 둠
     public AiResponse generate(AiRequest request) {
         User user = userRepository.findById(request.userId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.NOT_FOUND,
+                        "USER_NOT_FOUND",
+                        "사용자를 찾을 수 없습니다."
+                ));
 
         validateUserInfo(user);
 
@@ -54,15 +59,15 @@ public class AiService {
                 .call()
                 .content();
 
-        AiLog aiLog = AiLog.builder()
-                .userId(user.getId())
-                .routineId(request.routineId())
-                .requestType("ROUTINE_RECOMMEND")
-                .prompt(prompt)
-                .response(result)
-                .build();
-
-        aiLogRepository.save(aiLog);
+//        AiLog aiLog = AiLog.builder()
+//                .userId(user.getId())
+//                .routineId(request.routineId())
+//                .requestType("ROUTINE_RECOMMEND")
+//                .prompt(prompt)
+//                .response(result)
+//                .build();
+//
+//        aiLogRepository.save(aiLog);
 
         return new AiResponse(result);
     }
@@ -72,9 +77,11 @@ public class AiService {
         boolean missingAge = user.getAge() == null;
         boolean missingGender = user.getGender() == null;
 
-        if (missingRole || missingAge || missingGender) {
-            throw new BusinessException(ErrorCode.AI_PROFILE_INFO_REQUIRED);
-        }
+        throw new BusinessException(
+                HttpStatus.BAD_REQUEST,
+                "AI_PROFILE_INFO_REQUIRED",
+                "직업, 연령, 성별 정보를 입력해야 이용 가능한 서비스입니다."
+        );
     }
 
     private String convertGender(Integer gender) {

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -1,0 +1,88 @@
+package com.rutina.rutinabackend.domain.ailog.service;
+
+import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
+import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.BusinessException;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiService {
+
+    private final ChatClient chatClient;
+    private final UserRepository userRepository;
+    private final AiLogRepository aiLogRepository;
+
+    public AiService(
+            ChatClient.Builder chatClientBuilder,
+            UserRepository userRepository,
+            AiLogRepository aiLogRepository
+    ) {
+        this.chatClient = chatClientBuilder.build();
+        this.userRepository = userRepository;
+        this.aiLogRepository = aiLogRepository;
+    }
+
+    //간단하게 임시 프롬포트 작성해 둠
+    public AiResponse generate(AiRequest request) {
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        validateUserInfo(user);
+
+        String prompt = """
+                사용자 정보입니다.
+                
+                닉네임: %s
+                직업: %s
+                연령: %s
+                성별: %s
+                """.formatted(
+                user.getNickname(),
+                user.getRole(),
+                user.getAge(),
+                convertGender(user.getGender())
+        );
+
+        String result = chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content();
+
+        AiLog aiLog = AiLog.builder()
+                .userId(user.getId())
+                .routineId(request.routineId())
+                .requestType("ROUTINE_RECOMMEND")
+                .prompt(prompt)
+                .response(result)
+                .build();
+
+        aiLogRepository.save(aiLog);
+
+        return new AiResponse(result);
+    }
+
+    private void validateUserInfo(User user) {
+        boolean missingRole = user.getRole() == null || user.getRole().isBlank();
+        boolean missingAge = user.getAge() == null;
+        boolean missingGender = user.getGender() == null;
+
+        if (missingRole || missingAge || missingGender) {
+            throw new BusinessException(ErrorCode.AI_PROFILE_INFO_REQUIRED);
+        }
+    }
+
+    private String convertGender(Integer gender) {
+        return switch (gender) {
+            case 0 -> "남성";
+            case 1 -> "여성";
+            case 2 -> "기타";
+            default -> "미입력";
+        };
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
     // 인증 없이 접근 가능한 엔드포인트
     private static final String[] PUBLIC_URLS = {
             "/api/v1/auth/**",
+            "/api/ai/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,10 +13,14 @@ spring:
       ddl-auto: update
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
-# ai 연결 안 해서 일단 임시값
+# 제미나이 사용
   ai:
-    openai:
-      api-key: "dummy"
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY}
+        chat:
+          options:
+            model: gemini-2.5-flash
 
   autoconfigure:
     exclude:


### PR DESCRIPTION
## 관련 이슈

- Closes #14 

---

## 작업 내용

API 연동 환경 설정

- build.gradle의 Spring AI 의존성을 Gemini로 설정
- application.yaml에 Gemini 설정 추가

AI API 기본 구현

- 요청, 응답 DTO 구현
- AI 엔드포인트 구현

사용자 정보 검증

- userId 기반 사용자 조회 로직 구현
- 직업(role), 연령(age), 성별(gender) 필수값 검증 추가
- 필수 정보 누락 시 예외 응답 반환 구현

보안 설정

- /api/ai/** 테스트용 접근 허용 설정

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 로그 저장 기능 작성해 두었으나, 기능 구체화 이전이기 때문에 주석 처리