### PR TITLE
[Feat] JWT 인증 필터 구현 및 멀티 디바이스 RefreshToken 관리

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
@@ -1,8 +1,0 @@
-package com.rutina.rutinabackend.domain.refreshToken.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record TokenRefreshRequest(
-        @NotBlank String refreshToken
-) {
-}

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.domain.refreshToken.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/entity/RefreshToken.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/entity/RefreshToken.java
@@ -28,6 +28,9 @@ public class RefreshToken {
     @Column(name = "expires_at", nullable = false)
     private OffsetDateTime expiresAt;
 
+    @Column(name = "device")
+    private String device;
+
     @Column(name = "created_at", nullable = false, updatable = false,
             columnDefinition = "TIMESTAMPTZ DEFAULT now()")
     private OffsetDateTime createdAt;
@@ -36,11 +39,12 @@ public class RefreshToken {
             columnDefinition = "TIMESTAMPTZ DEFAULT now()")
     private OffsetDateTime updatedAt;
 
-    public static RefreshToken of(User user, String tokenValue, long expiryMs) {
+    public static RefreshToken of(User user, String tokenValue, long expiryMs, String device) {
         RefreshToken token = new RefreshToken();
         token.user = user;
         token.tokenValue = tokenValue;
         token.expiresAt = OffsetDateTime.now().plusNanos(expiryMs * 1_000_000L);
+        token.device = device;
         token.createdAt = OffsetDateTime.now();
         token.updatedAt = OffsetDateTime.now();
         return token;

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -11,5 +11,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByTokenValue(String tokenValue);
 
-    void deleteByUserId(Long userId);
+    void deleteByUserIdAndDevice(Long userId, String device);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -1,9 +1,13 @@
 package com.rutina.rutinabackend.domain.user.controller;
 
-import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.user.service.AuthService;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -18,7 +23,8 @@ public class AuthController {
 
     private final AuthService authService;
 
-    // 로컬 회원가입
+    @Operation(summary = "로컬 회원가입")
+    @SecurityRequirements({})
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
@@ -26,28 +32,36 @@ public class AuthController {
         return ApiResponse.created("회원가입이 완료되었습니다.", response);
     }
 
-    // 로컬 로그인
+    @Operation(summary = "로컬 로그인")
+    @SecurityRequirements({})
     @PostMapping("/login")
-    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
-        LoginResponse response = authService.login(request);
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request,
+                                            HttpServletRequest httpRequest) {
+        // User-Agent 헤더에서 기기 정보를 추출 후 refreshToken과 함께 저장
+        String device = httpRequest.getHeader("User-Agent");
+        LoginResponse response = authService.login(request, device);
         return ApiResponse.ok("로그인에 성공했습니다.", response);
     }
 
-    // 토큰 재발급
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public ApiResponse<LoginResponse> reissue(@RequestBody @Valid TokenRefreshRequest request) {
-        LoginResponse response = authService.reissue(request);
+    public ApiResponse<LoginResponse> reissue(HttpServletRequest httpRequest) {
+        String refreshToken = extractBearerToken(httpRequest);
+        String device = httpRequest.getHeader("User-Agent");
+        LoginResponse response = authService.reissue(refreshToken, device);
         return ApiResponse.ok("토큰이 재발급되었습니다.", response);
     }
 
-    // 로그아웃
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@RequestBody @Valid TokenRefreshRequest request) {
-        authService.logout(request);
+    public ApiResponse<Void> logout(HttpServletRequest httpRequest) {
+        String refreshToken = extractBearerToken(httpRequest);
+        authService.logout(refreshToken);
         return ApiResponse.ok("로그아웃되었습니다.", null);
     }
 
-    // 이메일 중복 확인
+    @Operation(summary = "이메일 중복 확인")
+    @SecurityRequirements({})
     @GetMapping("/check-email")
     public ApiResponse<Map<String, Boolean>> checkEmail(@RequestParam String email) {
         boolean isDuplicate = authService.checkEmailDuplicate(email);
@@ -55,5 +69,13 @@ public class AuthController {
                 isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다.",
                 Map.of("isDuplicate", isDuplicate)
         );
+    }
+
+    private String extractBearerToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
+        }
+        return header.substring(7);
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.rutina.rutinabackend.domain.user.controller;
 
+import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.user.service.AuthService;
-import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
@@ -44,19 +44,20 @@ public class AuthController {
     }
 
     @Operation(summary = "토큰 재발급")
+    @SecurityRequirements({})
     @PostMapping("/reissue")
-    public ApiResponse<LoginResponse> reissue(HttpServletRequest httpRequest) {
-        String refreshToken = extractBearerToken(httpRequest);
+    public ApiResponse<LoginResponse> reissue(@RequestBody @Valid TokenRefreshRequest request,
+                                              HttpServletRequest httpRequest) {
         String device = httpRequest.getHeader("User-Agent");
-        LoginResponse response = authService.reissue(refreshToken, device);
+        LoginResponse response = authService.reissue(request, device);
         return ApiResponse.ok("토큰이 재발급되었습니다.", response);
     }
 
     @Operation(summary = "로그아웃")
+    @SecurityRequirements({})
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(HttpServletRequest httpRequest) {
-        String refreshToken = extractBearerToken(httpRequest);
-        authService.logout(refreshToken);
+    public ApiResponse<Void> logout(@RequestBody @Valid TokenRefreshRequest request) {
+        authService.logout(request);
         return ApiResponse.ok("로그아웃되었습니다.", null);
     }
 
@@ -69,13 +70,5 @@ public class AuthController {
                 isDuplicate ? "이미 사용 중인 이메일입니다." : "사용 가능한 이메일입니다.",
                 Map.of("isDuplicate", isDuplicate)
         );
-    }
-
-    private String extractBearerToken(HttpServletRequest request) {
-        String header = request.getHeader("Authorization");
-        if (header == null || !header.startsWith("Bearer ")) {
-            throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
-        }
-        return header.substring(7);
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.rutina.rutinabackend.domain.user.service;
 
-import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import com.rutina.rutinabackend.domain.user.entity.User;
@@ -43,7 +42,7 @@ public class AuthService {
 
     // ── 로그인 ─────────────────────────────────────────────
     @Transactional
-    public LoginResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request, String device) {
 
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(ErrorCode.INVALID_CREDENTIALS::toException);
@@ -56,10 +55,10 @@ public class AuthService {
         String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
 
-        // 기존 refresh token 삭제 후 신규 저장 (1인 1토큰)
-        refreshTokenRepository.deleteByUserId(user.getId());
+        // 같은 기기 재로그인 시 해당 기기 토큰만 교체 (다른 기기 토큰 유지)
+        refreshTokenRepository.deleteByUserIdAndDevice(user.getId(), device);
         refreshTokenRepository.save(
-                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry())
+                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry(), device)
         );
 
         return LoginResponse.of(accessToken, refreshToken);
@@ -67,15 +66,15 @@ public class AuthService {
 
     // ── 토큰 재발급 (refresh token rotation) ────────────────
     @Transactional
-    public LoginResponse reissue(TokenRefreshRequest request) {
+    public LoginResponse reissue(String refreshToken, String device) {
 
         // JWT 서명·만료 검증
-        if (!jwtProvider.isValid(request.refreshToken())) {
+        if (!jwtProvider.isValid(refreshToken)) {
             throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
         }
 
         // DB에 저장된 토큰인지 확인
-        RefreshToken saved = refreshTokenRepository.findByTokenValue(request.refreshToken())
+        RefreshToken saved = refreshTokenRepository.findByTokenValue(refreshToken)
                 .orElseThrow(ErrorCode.INVALID_REFRESH_TOKEN::toException);
 
         // DB expires_at 만료 검증
@@ -93,16 +92,16 @@ public class AuthService {
         // 기존 토큰 교체
         refreshTokenRepository.delete(saved);
         refreshTokenRepository.save(
-                RefreshToken.of(user, newRefreshToken, jwtProvider.getRefreshTokenExpiry())
+                RefreshToken.of(user, newRefreshToken, jwtProvider.getRefreshTokenExpiry(), device)
         );
 
         return LoginResponse.of(newAccessToken, newRefreshToken);
     }
 
     // ── 로그아웃 ──────────────────────────────────────────────
-    @Transactional
-    public void logout(TokenRefreshRequest request) {
-        refreshTokenRepository.findByTokenValue(request.refreshToken())
+    @Transactional // refreshToken으로 기기별 로그아웃
+    public void logout(String refreshToken) {
+        refreshTokenRepository.findByTokenValue(refreshToken)
                 .ifPresent(refreshTokenRepository::delete);
     }
 

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.rutina.rutinabackend.domain.user.service;
 
+import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import com.rutina.rutinabackend.domain.user.entity.User;
@@ -66,19 +67,20 @@ public class AuthService {
 
     // ── 토큰 재발급 (refresh token rotation) ────────────────
     @Transactional
-    public LoginResponse reissue(String refreshToken, String device) {
+    public LoginResponse reissue(TokenRefreshRequest request, String device) {
 
         // JWT 서명·만료 검증
-        if (!jwtProvider.isValid(refreshToken)) {
+        if (!jwtProvider.isValid(request.refreshToken())) {
             throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
         }
 
         // DB에 저장된 토큰인지 확인
-        RefreshToken saved = refreshTokenRepository.findByTokenValue(refreshToken)
+        RefreshToken saved = refreshTokenRepository.findByTokenValue(request.refreshToken())
                 .orElseThrow(ErrorCode.INVALID_REFRESH_TOKEN::toException);
 
         // DB expires_at 만료 검증
         if (saved.getExpiresAt().isBefore(OffsetDateTime.now())) {
+            // 토근 삭제
             refreshTokenRepository.delete(saved);
             throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
         }
@@ -100,8 +102,8 @@ public class AuthService {
 
     // ── 로그아웃 ──────────────────────────────────────────────
     @Transactional // refreshToken으로 기기별 로그아웃
-    public void logout(String refreshToken) {
-        refreshTokenRepository.findByTokenValue(refreshToken)
+    public void logout(TokenRefreshRequest request) {
+        refreshTokenRepository.findByTokenValue(request.refreshToken())
                 .ifPresent(refreshTokenRepository::delete);
     }
 

--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.rutina.rutinabackend.global.config;
 
+import com.rutina.rutinabackend.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,14 +11,20 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     // 인증 없이 접근 가능한 엔드포인트
     private static final String[] PUBLIC_URLS = {
-            "/api/v1/auth/**",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/check-email",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",
@@ -32,7 +40,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_URLS).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 등록
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -22,9 +22,7 @@ public class SecurityConfig {
 
     // 인증 없이 접근 가능한 엔드포인트
     private static final String[] PUBLIC_URLS = {
-            "/api/v1/auth/signup",
-            "/api/v1/auth/login",
-            "/api/v1/auth/check-email",
+            "/api/v1/auth/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",

--- a/src/main/java/com/rutina/rutinabackend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SwaggerConfig.java
@@ -9,14 +9,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /*
-* Swagger UI 상단 Authorize 버튼에 AccessToken·RefreshToken 입력칸 제공
-* - signup/login/check-email → @SecurityRequirements({})로 인증 제외
-* */
+ * Swagger UI 상단 Authorize 버튼에 AccessToken 입력칸 제공
+ * - signup/login/check-email → 인증 불필요 (@SecurityRequirements({}) 적용)
+ * - reissue/logout → body의 refreshToken으로 자체 검증
+ * */
 @Configuration
 public class SwaggerConfig {
 
     public static final String ACCESS_TOKEN = "AccessToken";
-    public static final String REFRESH_TOKEN = "RefreshToken";
 
     @Bean
     public OpenAPI openAPI() {
@@ -25,22 +25,15 @@ public class SwaggerConfig {
                         .title("Rutina API")
                         .description("루티나 백엔드 API 명세서")
                         .version("v1"))
-                // 모든 API에 AccessToken·RefreshToken 인증 표시
+                // 모든 API에 AccessToken 인증 표시
                 .addSecurityItem(new SecurityRequirement()
-                        .addList(ACCESS_TOKEN)
-                        .addList(REFRESH_TOKEN))
+                        .addList(ACCESS_TOKEN))
                 .components(new Components()
                         .addSecuritySchemes(ACCESS_TOKEN, new SecurityScheme()
                                 .name(ACCESS_TOKEN)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
-                                .description("로그인 후 발급받은 Access Token을 입력하세요."))
-                        .addSecuritySchemes(REFRESH_TOKEN, new SecurityScheme()
-                                .name(REFRESH_TOKEN)
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                                .description("reissue / logout 요청 시 Refresh Token을 입력하세요.")));
+                                .description("로그인 후 발급받은 Access Token을 입력하세요.")));
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.rutina.rutinabackend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/*
+* Swagger UI 상단 Authorize 버튼에 AccessToken·RefreshToken 입력칸 제공
+* - signup/login/check-email → @SecurityRequirements({})로 인증 제외
+* */
+@Configuration
+public class SwaggerConfig {
+
+    public static final String ACCESS_TOKEN = "AccessToken";
+    public static final String REFRESH_TOKEN = "RefreshToken";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Rutina API")
+                        .description("루티나 백엔드 API 명세서")
+                        .version("v1"))
+                // 모든 API에 AccessToken·RefreshToken 인증 표시
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(ACCESS_TOKEN)
+                        .addList(REFRESH_TOKEN))
+                .components(new Components()
+                        .addSecuritySchemes(ACCESS_TOKEN, new SecurityScheme()
+                                .name(ACCESS_TOKEN)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("로그인 후 발급받은 Access Token을 입력하세요."))
+                        .addSecuritySchemes(REFRESH_TOKEN, new SecurityScheme()
+                                .name(REFRESH_TOKEN)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("reissue / logout 요청 시 Refresh Token을 입력하세요.")));
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rutina/rutinabackend/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.rutina.rutinabackend.global.jwt;
+
+import com.rutina.rutinabackend.global.security.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 모든 요청에 대해 한 번씩 실행(OncePerRequestFilter)
+ * Authorization 헤더의 Bearer 토큰 검증
+ * 유효한 경우 SecurityContext에 인증 정보를 저장
+ *
+ * 토큰이 없거나 유효하지 않으면 인증 없이 다음 필터로 넘김.
+ * (PUBLIC_URLS는 SecurityConfig에서 permitAll로 처리)
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        // Authorization 헤더가 없거나 Bearer 형식이 아니면 인증 없이 통과
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // Bearer 이후의 토큰 값만 추출
+        String token = header.substring(7);
+
+        // 서명 및 만료 검증 후 SecurityContext에 인증 정보 저장
+        if (jwtProvider.isValid(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            UserDetails userDetails = userDetailsService.loadUserById(userId);
+
+            // 인증 객체 생성 (credentials는 이미 토큰으로 검증했으므로 null)
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+
+            // 부가 정보 설정(요청 IP, 세션 정보 등)
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)
+            );
+
+            // 이후 컨트롤러에서 @AuthenticationPrincipal로 꺼낼 수 있도록 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/security/CustomUserDetailsService.java
@@ -1,0 +1,43 @@
+package com.rutina.rutinabackend.global.security;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // Spring Security 기본 메서드 (email 기반)
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+        return toUserDetails(user);
+    }
+
+    // JWT 필터에서 userId 기반으로 조회
+    public UserDetails loadUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
+        return toUserDetails(user);
+    }
+
+    // User 엔티티 -> UserDetails 객체로 변환.(Spring Security가 인식 가능)
+    private UserDetails toUserDetails(User user) {
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(String.valueOf(user.getId()))
+                .password(user.getPassword() != null ? user.getPassword() : "")
+                .authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())))
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #21 

---

## 작업 내용

- JWT 기반 인증 체계 설정
- RefreshToken 엔티티에 기기(device) 정보를 추가
- JWT 필터·UserDetailsService를 신규 구현하여 로그인·토큰 재발급·로그아웃 플로우 완성
- Swagger UI에서 토큰 인증을 테스트할 수 있도록 SecurityScheme 설정 추가
- 토큰 전달 방식 일관성 개선 (header: accessToken만 수신, body: refreshToken으로 변경)

RefreshToken.java - device 필드 및 of() 팩토리 메서드 추가
TokenRefreshRequest.java - 미사용 DTO 삭제
RefreshTokenRepository.java- deleteByUserIdAndDevice() 메서드 추가
CustomUserDetailsService.java - userId·email 기반 UserDetails 조회 서비스 신규 구현
JwtAuthenticationFilter.java - Bearer 토큰 검증 후 SecurityContext 등록하는 필터 신규 구현
AuthService.java - 로그인·재발급·로그아웃 로직 및 기기별 토큰 관리 구현
AuthController.java - /reissue, /logout 엔드포인트 추가, Swagger 어노테이션 적용
SecurityConfig.java - JwtAuthenticationFilter 연동, reissue·logout PUBLIC_URLS 제외, Stateless 세션 정책 적용
SwaggerConfig.java - Swagger UI AccessToken 인증 스킴만 유지, RefreshToken 헤더 제거

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인
- [x] 토큰 재발급 요청 형식 변경 후 정상 동작 확인

---

## 참고사항

- 인증(AccessToken)이 필요없는 엔드포인트에는 @SecurityRequirements({}) 붙이면 인증 제외됩니다.
- 인증(AccessToken)이 필요한 엔드포인트라면 아무것도 안 해도 JwtAuthenticationFilter와 SecurityConfig가 알아서 토큰 검증합니다.
JwtAuthenticationFilter → 토큰 검증 후 SecurityContext에 저장
SecurityConfig → SecurityContext에 인증 정보 없으면 401 반환
- 그리고 @Operation(summary = "로컬 회원가입") 이렇게 summary 적어주면 swagger에 설명도 같이 뜹니다.

<img  height="140" alt="image" src="https://github.com/user-attachments/assets/2b789f18-2113-43c0-9c07-39068b3f77a1" />
<img height="150" alt="image" src="https://github.com/user-attachments/assets/b59e7f40-e499-490f-9b66-56fdfb49376b" />  

- 아래와 같이 작성하여 userId도 얻으면 됩니다.
```
@GetMapping("/")
public ApiResponse<?> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
    Long userId = Long.valueOf(userDetails.getUsername());
    // userId로 DB 조회 등 비즈니스 로직
}
```