### PR TITLE
[Feat] 카테고리 CRUD 및 검증 로직 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
@@ -1,0 +1,114 @@
+package com.rutina.rutinabackend.domain.category.controller;
+
+import com.rutina.rutinabackend.domain.category.dto.CategoryCreateRequest;
+import com.rutina.rutinabackend.domain.category.dto.CategoryOrderUpdateRequest;
+import com.rutina.rutinabackend.domain.category.dto.CategoryResponse;
+import com.rutina.rutinabackend.domain.category.dto.CategoryUpdateRequest;
+import com.rutina.rutinabackend.domain.category.service.CategoryService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+@Tag(name = "Category", description = "카테고리 API")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @Operation(summary = "카테고리 생성")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CategoryResponse> createCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody CategoryCreateRequest request
+    ) {
+        // 현재 프로젝트의 인증 구조에서는
+        // UserDetails.username 자리에 userId가 문자열로 들어가 있으므로 Long으로 변환해서 사용
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        // 카테고리 생성 서비스 호출
+        CategoryResponse response = categoryService.createCategory(userId, request);
+
+        // 공통 응답 포맷으로 반환
+        return ApiResponse.created("카테고리가 생성되었습니다.", response);
+    }
+
+    @Operation(summary = "내 카테고리 목록 조회")
+    @GetMapping
+    public ApiResponse<List<CategoryResponse>> getCategories(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        // accessToken 인증 사용자 기준으로 본인 카테고리만 조회
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<CategoryResponse> response = categoryService.getCategories(userId);
+        return ApiResponse.ok("카테고리 목록 조회에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "카테고리 단건 조회")
+    @GetMapping("/{categoryId}")
+    public ApiResponse<CategoryResponse> getCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long categoryId
+    ) {
+        // path variable로 받은 categoryId와 로그인 userId를 함께 사용해서
+        // 본인 카테고리만 조회 가능하도록 처리
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        CategoryResponse response = categoryService.getCategory(userId, categoryId);
+        return ApiResponse.ok("카테고리 조회에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "카테고리 수정")
+    @PatchMapping("/{categoryId}")
+    public ApiResponse<CategoryResponse> updateCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long categoryId,
+            @Valid @RequestBody CategoryUpdateRequest request
+    ) {
+        // 카테고리 이름, 색상 수정
+        // 순서는 여기서 수정하지 않고 reorder API에서만 변경
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        CategoryResponse response = categoryService.updateCategory(userId, categoryId, request);
+        return ApiResponse.ok("카테고리가 수정되었습니다.", response);
+    }
+
+    @Operation(summary = "카테고리 순서 변경")
+    @PatchMapping("/reorder")
+    public ApiResponse<Void> reorderCategories(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody CategoryOrderUpdateRequest request
+    ) {
+        // 프론트에서 드래그 후 최종 순서대로 categoryIds 배열을 보내면
+        // 서비스에서 해당 순서대로 sortOrder를 다시 저장
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        categoryService.updateCategoryOrder(userId, request);
+        return ApiResponse.ok("카테고리 순서가 변경되었습니다.", null);
+    }
+
+    @Operation(summary = "카테고리 삭제")
+    @DeleteMapping("/{categoryId}")
+    public ApiResponse<Void> deleteCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long categoryId
+    ) {
+        // 카테고리 삭제 전 프론트에서 한 번 더 확인 모달을 띄우는 것을 전제로 함
+        // 실제 삭제 로직은 서비스에서 처리
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        categoryService.deleteCategory(userId, categoryId);
+        return ApiResponse.ok("카테고리가 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
@@ -70,7 +70,7 @@ public class CategoryController {
     }
 
     @Operation(summary = "카테고리 수정")
-    @PatchMapping("/{categoryId}")
+    @PutMapping("/{categoryId}")
     public ApiResponse<CategoryResponse> updateCategory(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long categoryId,
@@ -85,7 +85,7 @@ public class CategoryController {
     }
 
     @Operation(summary = "카테고리 순서 변경")
-    @PatchMapping("/reorder")
+    @PutMapping("/reorder")
     public ApiResponse<Void> reorderCategories(
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody CategoryOrderUpdateRequest request

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryCreateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryCreateRequest.java
@@ -1,0 +1,27 @@
+package com.rutina.rutinabackend.domain.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryCreateRequest {
+
+    // 카테고리 이름
+    // - 최대 20자 제한
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    @Size(max = 20, message = "카테고리 이름은 20자 이하로 입력해주세요.")
+    private String name;
+
+    // 색상 코드
+    // - #RRGGBB 형식만 허용
+    @NotBlank(message = "색상 코드는 필수입니다.")
+    @Pattern(
+            regexp = "^#[0-9A-Fa-f]{6}$",
+            message = "색상 코드는 #RRGGBB 형식이어야 합니다."
+    )
+    private String colorCode;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryOrderUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryOrderUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.rutina.rutinabackend.domain.category.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CategoryOrderUpdateRequest {
+
+    // 드래그 후 최종 순서대로 category id 목록을 전달
+    // 예: [3, 1, 2]
+    // - 3번 카테고리 -> sortOrder 0
+    // - 1번 카테고리 -> sortOrder 1
+    // - 2번 카테고리 -> sortOrder 2
+    @NotEmpty(message = "카테고리 순서 정보는 비어 있을 수 없습니다.")
+    private List<Long> categoryIds;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
@@ -1,0 +1,37 @@
+package com.rutina.rutinabackend.domain.category.dto;
+
+import com.rutina.rutinabackend.domain.category.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CategoryResponse {
+
+    // 카테고리 식별자
+    private Long id;
+
+    // 카테고리 이름
+    private String name;
+
+    // 색상 코드
+    private String colorCode;
+
+    // 카테고리에 속한 루틴 집계값
+    private String rtSum;
+
+    // 실제 표시 순서
+    // 목록 조회 시 프론트가 현재 순서를 알 수 있도록 응답에 포함
+    private Integer sortOrder;
+
+    // Entity -> Response DTO 변환
+    public static CategoryResponse from(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .colorCode(category.getColorCode())
+                .rtSum(category.getRtSum())
+                .sortOrder(category.getSortOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.rutina.rutinabackend.domain.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryUpdateRequest {
+
+    // 카테고리 수정 시 이름 검증
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    @Size(max = 20, message = "카테고리 이름은 20자 이하로 입력해주세요.")
+    private String name;
+
+    // 카테고리 수정 시 색상 코드 검증
+    @NotBlank(message = "색상 코드는 필수입니다.")
+    @Pattern(
+            regexp = "^#[0-9A-Fa-f]{6}$",
+            message = "색상 코드는 #RRGGBB 형식이어야 합니다."
+    )
+    private String colorCode;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
@@ -19,14 +19,13 @@ public class Category {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(name = "color_code", nullable = false)
+    @Column(name = "color_code", nullable = false, length = 7)
     private String colorCode;
 
-
-    @Column(name = "rt_sum", nullable = false)
+    @Column(name = "rt_sum", nullable = false, length = 10)
     private String rtSum;   // 카테고리 루틴 집계값
 
     @Column(name = "sort_order", nullable = false)
@@ -51,5 +50,12 @@ public class Category {
         category.createdAt = OffsetDateTime.now();
         category.updatedAt = OffsetDateTime.now();
         return category;
+    }
+    // ── 카테고리 수정 시 사용 ──────────────────────────
+    public void update(String name, String colorCode, Integer sortOrder) {
+        this.name = name;
+        this.colorCode = colorCode;
+        this.sortOrder = sortOrder;
+        this.updatedAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
@@ -55,7 +55,13 @@ public class Category {
     public void update(String name, String colorCode, Integer sortOrder) {
         this.name = name;
         this.colorCode = colorCode;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    // ── 드래그 정렬 시 순서값 변경  ──────────────────────────
+    public void updateSortOrder(Integer sortOrder) {
         this.sortOrder = sortOrder;
         this.updatedAt = OffsetDateTime.now();
     }
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
@@ -52,7 +52,7 @@ public class Category {
         return category;
     }
     // ── 카테고리 수정 시 사용 ──────────────────────────
-    public void update(String name, String colorCode, Integer sortOrder) {
+    public void update(String name, String colorCode) {
         this.name = name;
         this.colorCode = colorCode;
         this.updatedAt = OffsetDateTime.now();

--- a/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
@@ -5,8 +5,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    List<Category> findByUserId(Long userId);
+    // 내 카테고리 목록 조회
+    List<Category> findAllByUser_IdOrderBySortOrderAscIdAsc(Long userId);
+
+    // 내 카테고리 단건 조회
+    Optional<Category> findByIdAndUser_Id(Long categoryId, Long userId);
+
+    // 생성 시 이름 중복 체크
+    boolean existsByUser_IdAndName(Long userId, String name);
+
+    // 수정 시 자기 자신 제외 이름 중복 체크
+    boolean existsByUser_IdAndNameAndIdNot(Long userId, String name, Long categoryId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
@@ -10,8 +10,8 @@ import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.BusinessException;
-import com.rutina.rutinabackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,11 +38,11 @@ public class CategoryService {
 
         // 같은 사용자 기준 이름 중복 방지
         if (categoryRepository.existsByUser_IdAndName(userId, categoryName)) {
-            throw new BusinessException(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS);
+            throw new BusinessException(HttpStatus.CONFLICT, "CATEGORY_409", "이미 같은 이름의 카테고리가 존재합니다.");
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "USER_404", "사용자를 찾을 수 없습니다."));
 
         // 기존 카테고리를 전부 뒤로 한 칸씩 밀어서
         // 새 카테고리가 0번 순서로 들어갈 수 있게 함
@@ -85,7 +85,7 @@ public class CategoryService {
         String categoryName = request.getName().trim();
 
         if (categoryRepository.existsByUser_IdAndNameAndIdNot(userId, categoryName, categoryId)) {
-            throw new BusinessException(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS);
+            throw new BusinessException(HttpStatus.CONFLICT, "CATEGORY_409", "이미 같은 이름의 카테고리가 존재합니다.");
         }
 
         category.update(
@@ -106,7 +106,7 @@ public class CategoryService {
 
         // 사용자의 전체 카테고리 개수와 요청 개수가 다르면 잘못된 요청
         if (categories.size() != requestIds.size()) {
-            throw new BusinessException(ErrorCode.INVALID_CATEGORY_ORDER_REQUEST);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "CATEGORY_400", "잘못된 카테고리 순서 요청입니다.");
         }
 
         // 요청으로 들어온 id들이 정말 이 사용자의 카테고리 id 목록과 일치하는지 검증
@@ -120,7 +120,7 @@ public class CategoryService {
                 .toList();
 
         if (!ownedIds.equals(sortedRequestIds)) {
-            throw new BusinessException(ErrorCode.INVALID_CATEGORY_ORDER_REQUEST);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "CATEGORY_400", "잘못된 카테고리 순서 요청입니다.");
         }
 
         // id -> Category 매핑
@@ -139,10 +139,10 @@ public class CategoryService {
     public void deleteCategory(Long userId, Long categoryId) {
         Category category = findCategory(userId, categoryId);
 
-        // FK 충돌 방지를 위해
-        // 이 카테고리를 참조하는 루틴들의 category_id를 먼저 null 처리
-        routineRepository.clearCategoryFromRoutines(userId, categoryId);
+        // 해당 카테고리에 속한 루틴도 함께 삭제
+        routineRepository.deleteByUserIdAndCategoryId(userId, categoryId);
 
+        // 그 다음 카테고리 삭제
         categoryRepository.delete(category);
     }
 
@@ -150,6 +150,6 @@ public class CategoryService {
     // 항상 userId까지 같이 걸어서 본인 카테고리만 접근 가능하게 함
     private Category findCategory(Long userId, Long categoryId) {
         return categoryRepository.findByIdAndUser_Id(categoryId, userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "CATEGORY_404", "카테고리를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
@@ -1,0 +1,155 @@
+package com.rutina.rutinabackend.domain.category.service;
+
+import com.rutina.rutinabackend.domain.category.dto.CategoryCreateRequest;
+import com.rutina.rutinabackend.domain.category.dto.CategoryOrderUpdateRequest;
+import com.rutina.rutinabackend.domain.category.dto.CategoryResponse;
+import com.rutina.rutinabackend.domain.category.dto.CategoryUpdateRequest;
+import com.rutina.rutinabackend.domain.category.entity.Category;
+import com.rutina.rutinabackend.domain.category.repository.CategoryRepository;
+import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.BusinessException;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final RoutineRepository routineRepository;
+
+    // 카테고리 생성
+    // 정책:
+    // - 새 카테고리는 항상 맨 위에 오도록 sortOrder = 0
+    // - 기존 카테고리들은 sortOrder를 1씩 뒤로 밀어냄
+    @Transactional
+    public CategoryResponse createCategory(Long userId, CategoryCreateRequest request) {
+        String categoryName = request.getName().trim();
+
+        // 같은 사용자 기준 이름 중복 방지
+        if (categoryRepository.existsByUser_IdAndName(userId, categoryName)) {
+            throw new BusinessException(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 기존 카테고리를 전부 뒤로 한 칸씩 밀어서
+        // 새 카테고리가 0번 순서로 들어갈 수 있게 함
+        List<Category> categories = categoryRepository.findAllByUser_IdOrderBySortOrderAscIdAsc(userId);
+        for (Category category : categories) {
+            category.updateSortOrder(category.getSortOrder() + 1);
+        }
+
+        Category newCategory = Category.create(
+                user,
+                categoryName,
+                request.getColorCode(),
+                "0",
+                0
+        );
+
+        Category savedCategory = categoryRepository.save(newCategory);
+        return CategoryResponse.from(savedCategory);
+    }
+
+    // 내 카테고리 전체 조회
+    public List<CategoryResponse> getCategories(Long userId) {
+        return categoryRepository.findAllByUser_IdOrderBySortOrderAscIdAsc(userId)
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
+    // 내 카테고리 단건 조회
+    public CategoryResponse getCategory(Long userId, Long categoryId) {
+        Category category = findCategory(userId, categoryId);
+        return CategoryResponse.from(category);
+    }
+
+    // 카테고리 수정
+    // 이름, 색상만 수정하고 순서는 건드리지 않음
+    @Transactional
+    public CategoryResponse updateCategory(Long userId, Long categoryId, CategoryUpdateRequest request) {
+        Category category = findCategory(userId, categoryId);
+        String categoryName = request.getName().trim();
+
+        if (categoryRepository.existsByUser_IdAndNameAndIdNot(userId, categoryName, categoryId)) {
+            throw new BusinessException(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS);
+        }
+
+        category.update(
+                categoryName,
+                request.getColorCode()
+        );
+
+        return CategoryResponse.from(category);
+    }
+
+    // 카테고리 순서 변경
+    // 프론트가 드래그 후 최종 순서대로 id 목록 전체를 보내면
+    // 그 순서대로 sortOrder를 다시 저장
+    @Transactional
+    public void updateCategoryOrder(Long userId, CategoryOrderUpdateRequest request) {
+        List<Category> categories = categoryRepository.findAllByUser_IdOrderBySortOrderAscIdAsc(userId);
+        List<Long> requestIds = request.getCategoryIds();
+
+        // 사용자의 전체 카테고리 개수와 요청 개수가 다르면 잘못된 요청
+        if (categories.size() != requestIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_CATEGORY_ORDER_REQUEST);
+        }
+
+        // 요청으로 들어온 id들이 정말 이 사용자의 카테고리 id 목록과 일치하는지 검증
+        List<Long> ownedIds = categories.stream()
+                .map(Category::getId)
+                .sorted()
+                .toList();
+
+        List<Long> sortedRequestIds = requestIds.stream()
+                .sorted()
+                .toList();
+
+        if (!ownedIds.equals(sortedRequestIds)) {
+            throw new BusinessException(ErrorCode.INVALID_CATEGORY_ORDER_REQUEST);
+        }
+
+        // id -> Category 매핑
+        Map<Long, Category> categoryMap = categories.stream()
+                .collect(Collectors.toMap(Category::getId, category -> category));
+
+        // 프론트가 보낸 순서대로 sortOrder 재설정
+        for (int i = 0; i < requestIds.size(); i++) {
+            Category category = categoryMap.get(requestIds.get(i));
+            category.updateSortOrder(i);
+        }
+    }
+
+    // 카테고리 삭제
+    @Transactional
+    public void deleteCategory(Long userId, Long categoryId) {
+        Category category = findCategory(userId, categoryId);
+
+        // FK 충돌 방지를 위해
+        // 이 카테고리를 참조하는 루틴들의 category_id를 먼저 null 처리
+        routineRepository.clearCategoryFromRoutines(userId, categoryId);
+
+        categoryRepository.delete(category);
+    }
+
+    // 공통 조회 메서드
+    // 항상 userId까지 같이 걸어서 본인 카테고리만 접근 가능하게 함
+    private Category findCategory(Long userId, Long categoryId) {
+        return categoryRepository.findByIdAndUser_Id(categoryId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
@@ -36,13 +36,15 @@ public class CategoryService {
     public CategoryResponse createCategory(Long userId, CategoryCreateRequest request) {
         String categoryName = request.getName().trim();
 
+        //사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "USER_404", "사용자를 찾을 수 없습니다."));
+
         // 같은 사용자 기준 이름 중복 방지
         if (categoryRepository.existsByUser_IdAndName(userId, categoryName)) {
             throw new BusinessException(HttpStatus.CONFLICT, "CATEGORY_409", "이미 같은 이름의 카테고리가 존재합니다.");
         }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "USER_404", "사용자를 찾을 수 없습니다."));
 
         // 기존 카테고리를 전부 뒤로 한 칸씩 밀어서
         // 새 카테고리가 0번 순서로 들어갈 수 있게 함

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
@@ -10,4 +10,8 @@ import java.util.List;
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
     List<Routine> findByUserId(Long userId);
     List<Routine> findByUserIdAndCategoryId(Long userId, Long categoryId);
+
+    long countByUserIdAndCategoryId(Long userId, Long categoryId);
+
+    void deleteByUserIdAndCategoryId(Long userId, Long categoryId);
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #20 

---

## 작업 내용

- 카테고리 CRUD API 구현
- 카테고리 순서 변경 API 추가
- 카테고리 생성 시 최신 카테고리가 상단에 오도록 정렬 로직 반영
- Spring Security 인증 사용자 기준으로 본인 카테고리만 조회/수정/삭제되도록 처리
- Swagger 확인용 `@Operation` 및 주석 정리
- 카테고리 삭제 시 연관 루틴 처리 로직 반영

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인
- [x] Swagger에서 카테고리 생성 API 테스트 완료
- [x] 인증 사용자 기준 카테고리 생성/조회 동작 확인

---

## 참고사항

- 카테고리 순서 변경은 프론트에서 드래그로 변경 후 `categoryIds` 배열 전체를 전달하는 방식 채택
- 카테고리 생성 시 기본 정렬은 최신 생성 순으로 보이도록 처리했
- 카테고리 생성 시 기존 카테고리들의 `sortOrder`를 1씩 증가시키고, 새 카테고리를 `sortOrder = 0`으로 저장하도록 구현

### 백엔드에서 구현한 검증 로직
- 카테고리 생성/수정 시 이름 필수값 검증
- 카테고리 생성/수정 시 이름 최대 20자 검증
- 카테고리 생성/수정 시 색상 코드 필수값 검증
- 카테고리 생성/수정 시 색상 코드 `#RRGGBB` 형식 검증
- 카테고리 순서 변경 시 `categoryIds` 비어 있음 검증
- 카테고리 순서 변경 요청은 프론트에서 전달한 최종 카테고리 ID 배열 기준으로 처리되도록 DTO 구성
- 응답 DTO를 통해 카테고리 정보(id, name, colorCode, rtSum, sortOrder) 일관되게 반환하도록 구성