### PR TITLE
[Feat] 카카오/네이버 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -10,7 +10,7 @@ import java.time.OffsetDateTime;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("deleted_at IS NULL")   // soft delete - 조회 시 자동 필터링
+@SQLRestriction("deleted_at IS NULL")   // soft delete - 조회 시 자동 필터만
 public class User {
 
     @Id
@@ -49,7 +49,7 @@ public class User {
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
 
-    // ── 일반 회원가입용 정적 팩토리 ──────────────────────────
+    // 일반 회원가입용 정적 팩토리 메서드
     public static User createLocal(String email, String encodedPassword, String nickname) {
         User user = new User();
         user.email = email;
@@ -61,4 +61,18 @@ public class User {
         user.updatedAt = OffsetDateTime.now();
         return user;
     }
+
+    // 소셜 로그인 정적 팩토리 메서드
+    public static User createOAuth(String email, String nickname, String provider, String providerId) {
+        User user = new User();
+        user.email = email;
+        user.nickname = nickname;
+        user.role = "USER";
+        user.provider = provider;
+        user.providerId = providerId;
+        user.createdAt = OffsetDateTime.now();
+        user.updatedAt = OffsetDateTime.now();
+        return user;
+    }
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
 }

--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.rutina.rutinabackend.global.config;
 
 import com.rutina.rutinabackend.global.jwt.JwtAuthenticationFilter;
+import com.rutina.rutinabackend.global.oauth2.CustomOAuth2UserService;
+import com.rutina.rutinabackend.global.oauth2.OAuth2FailureHandler;
+import com.rutina.rutinabackend.global.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -19,6 +23,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
 
     // 인증 없이 접근 가능한 엔드포인트
     private static final String[] PUBLIC_URLS = {
@@ -27,6 +34,9 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/v3/api-docs/**",
             "/swagger-config",
+            "/error",
+            "/login/oauth2/**",    // 카카오/네이버 콜백 수신
+            "/oauth2/**",          // 소셜 로그인 시작 요청
     };
 
     @Bean
@@ -38,6 +48,18 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_URLS).permitAll()
                         .anyRequest().authenticated()
+                )
+                // OAuth2 소셜 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestRepository( // STATELESS 세션 정책에서도 OAuth2 state 파라미터 검증을 위해
+                                                                 // 인가 요청 정보를 세션에 임시 저장 (로그인 완료 후 세션 소멸)
+                                        new HttpSessionOAuth2AuthorizationRequestRepository() // OAuth2 state만 세션 사용
+                                )
+                        )
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
                 )
                 // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 등록
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2UserInfo userInfo = getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
+
+        if (isBlank(userInfo.getProviderId())) {
+            throw oauth2Error("OAuth2 account information is incomplete");
+        }
+        // 이메일 비제공 계정은 가상 이메일 생성 (카카오는 이메일 미동의 가능)
+        String email = isBlank(userInfo.getEmail())
+                ? userInfo.getProvider().toLowerCase() + "_" + userInfo.getProviderId() + "@social.local"
+                : userInfo.getEmail();
+
+        // provider + providerId 기준으로 기존 회원 조회, 없으면 자동 가입
+        User user = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
+                .orElseGet(() -> userRepository.save(
+                        User.createOAuth(
+                                email,
+                                defaultNickname(userInfo, email),
+                                userInfo.getProvider(),
+                                userInfo.getProviderId()
+                        )
+                ));
+
+        Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
+        attributes.put("userId", user.getId());
+
+        return new DefaultOAuth2User(
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())),
+                attributes,
+                "userId"
+        );
+    }
+
+    private OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "kakao" -> new KakaoUserInfo(attributes);
+            case "naver" -> new NaverUserInfo(attributes);
+            default -> throw oauth2Error("Unsupported provider: " + registrationId);
+        };
+    }
+
+    private String defaultNickname(OAuth2UserInfo userInfo, String email) {
+        if (!isBlank(userInfo.getNickname())) {
+            return userInfo.getNickname();
+        }
+        return email.split("@")[0];
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private OAuth2AuthenticationException oauth2Error(String message) {
+        return new OAuth2AuthenticationException(
+                new OAuth2Error("invalid_oauth2_user"),
+                message
+        );
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -42,15 +42,20 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         // provider + providerId 기준으로 기존 회원 조회, 없으면 자동 가입
         User user = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
-                .orElseGet(() -> userRepository.save(
-                        User.createOAuth(
-                                email,
-                                defaultNickname(userInfo, email),
-                                userInfo.getProvider(),
-                                userInfo.getProviderId()
-                        )
-                ));
-
+                .orElseGet(() -> {
+                    // 동일 이메일 계정 존재 시 예외 처리
+                    if (userRepository.existsByEmail(email)) {
+                        throw oauth2Error("An account with the same email already exists");
+                    }
+                    return userRepository.save(
+                            User.createOAuth(
+                                    email,
+                                    defaultNickname(userInfo, email),
+                                    userInfo.getProvider(),
+                                    userInfo.getProviderId()
+                            )
+                    );
+                });
         Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
         attributes.put("userId", user.getId());
 

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/KakaoUserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/KakaoUserInfo.java
@@ -1,0 +1,42 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    @SuppressWarnings("unchecked")
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = kakaoAccount == null
+                ? Map.of()
+                : (Map<String, Object>) kakaoAccount.getOrDefault("profile", Map.of());
+    }
+
+    @Override
+    public String getProvider() {
+        return "KAKAO";
+    }
+
+    @Override
+    public String getProviderId() {
+        Object id = attributes.get("id");
+        return id == null ? null : String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = kakaoAccount == null ? null : kakaoAccount.get("email");
+        return email == null ? null : String.valueOf(email);
+    }
+
+    @Override
+    public String getNickname() {
+        Object nickname = profile.get("nickname");
+        return nickname == null ? null : String.valueOf(nickname);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/NaverUserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/NaverUserInfo.java
@@ -1,0 +1,36 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import java.util.Map;
+
+public class NaverUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> response;
+
+    @SuppressWarnings("unchecked")
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.response = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+        return "NAVER";
+    }
+
+    @Override
+    public String getProviderId() {
+        Object id = response == null ? null : response.get("id");
+        return id == null ? null : String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = response == null ? null : response.get("email");
+        return email == null ? null : String.valueOf(email);
+    }
+
+    @Override
+    public String getNickname() {
+        Object name = response == null ? null : response.get("name");
+        return name == null ? null : String.valueOf(name);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,33 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${oauth2.redirect-url}")
+    private String redirectUrl;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException, ServletException {
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
+                .queryParam("error", "social_login_failed")
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,63 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
+import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import com.rutina.rutinabackend.global.jwt.JwtProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${oauth2.redirect-url}")
+    private String redirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        Long userId = Long.valueOf(String.valueOf(oauth2User.getAttributes().get("userId")));
+        String device = request.getHeader("User-Agent"); // 기기별 RefreshToken 관리용
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
+
+        refreshTokenRepository.deleteByUserIdAndDevice(user.getId(), device);
+        refreshTokenRepository.save(
+                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry(), device)
+        );
+
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("tokenType", "Bearer")
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+public interface OAuth2UserInfo {
+    String getProvider();
+    String getProviderId();
+    String getEmail();
+    String getNickname();
+}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
       ddl-auto: update
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
-# ai 연결 안 해서 일단 임시값
+  # ai 연결 안 해서 일단 임시값
   ai:
     openai:
       api-key: "dummy"
@@ -23,7 +23,46 @@ spring:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
 
+  # ── 소셜 로그인 ──────────────────────────────────────────
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            scope: profile_nickname
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            authorization-grant-type: authorization_code
+            scope: name, email
+            client-name: Naver
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiry: 1800000       # 30분
   refresh-token-expiry: 604800000    # 7일
+
+# ── 소셜 로그인 리다이렉트 URL (환경별로 분리) ────────────────
+oauth2:
+  redirect-url: ${OAUTH2_REDIRECT_URL:http://localhost:3000/oauth/callback}


### PR DESCRIPTION
## 관련 이슈

- Closes #23

---

## 작업 내용

- `OAuth2UserInfo` - 소셜 로그인 공통 인터페이스 정의
- `KakaoUserInfo` - 카카오 응답 구조에 맞는 유저 정보 파싱 구현
- `NaverUserInfo` - 네이버 응답 구조에 맞는 유저 정보 파싱 구현
- `CustomOAuth2UserService` - 소셜 계정 조회 및 신규 유저 자동 가입 처리, 동일 이메일 중복 예외 처리
- `OAuth2SuccessHandler` - 로그인 성공 시 JWT 발급 후 프론트엔드로 리다이렉트
- `OAuth2FailureHandler` - 로그인 실패 시 에러 쿼리 파라미터와 함께 리다이렉트
- `User.java` - 소셜 유저 생성용 `createOAuth()` 팩토리 메서드 추가
- `UserRepository.java` - `findByProviderAndProviderId()` 메서드 추가
- `SecurityConfig.java` - OAuth2 로그인 설정 추가, OAuth2 콜백 경로 PUBLIC_URLS 등록, `HttpSessionOAuth2AuthorizationRequestRepository` 명시로 state 검증 보장
- `application.yaml` - 카카오·네이버 OAuth2 클라이언트 설정 및 리다이렉트 URL 환경변수 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [x] 카카오 로그인 → JWT 발급 → 리다이렉트 정상 동작 확인
- [x] 네이버 로그인 → JWT 발급 → 리다이렉트 정상 동작 확인
---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
 **소셜 로그인 흐름**
> 1. 프론트에서 `/oauth2/authorization/kakao` 또는 `/oauth2/authorization/naver` 로 진입
> 2. 각 플랫폼 인증 완료 후 `/login/oauth2/code/{provider}` 로 콜백
> 3. 로그인 성공 시 아래 형태로 프론트에 리다이렉트

**환경변수 추가 필요**
> 실제 키값은 팀 내부 채널로 공유드리겠습니다.