### PR TITLE
[Refactor] routines 반복 스케줄 컬럼 구조 변경 및 필수값 제약 추가

### DIFF
--- a/src/main/resources/db/migration/V4__update_routine_repeat_and_state.sql
+++ b/src/main/resources/db/migration/V4__update_routine_repeat_and_state.sql
@@ -1,0 +1,22 @@
+----------------------------------------
+-- routines 테이블 반복 방식 변경 및 state 컬럼 제거
+----------------------------------------
+
+-- 1. 기존 컬럼 제거
+ALTER TABLE public.routines
+    DROP COLUMN cron_expression,
+    DROP COLUMN state;
+
+-- 2. 반복 관련 컬럼 추가
+ALTER TABLE public.routines
+    ADD COLUMN repeat_type     varchar(10) NOT NULL DEFAULT 'NONE',
+    ADD COLUMN repeat_interval integer,
+    ADD COLUMN repeat_unit     varchar(10),
+    ADD COLUMN repeat_days     varchar(50);
+
+-- 3. start_at NOT NULL 변경
+UPDATE public.routines SET start_at = CURRENT_DATE WHERE start_at IS NULL;
+ALTER TABLE public.routines ALTER COLUMN start_at SET NOT NULL;
+
+-- 4. category_id NOT NULL 변경
+ALTER TABLE public.routines ALTER COLUMN category_id SET NOT NULL;


### PR DESCRIPTION
## 관련 이슈
- Closes #29 

---

## 작업 내용
- routines 테이블의 `cron_expression`, `state` 컬럼 제거
- 구조화된 반복 스케줄 컬럼 추가 (`repeat_type`, `repeat_interval`, `repeat_unit`, `repeat_days`)
- `start_at`, `category_id`에 NOT NULL 제약 추가 (기존 NULL 데이터는 `CURRENT_DATE`로 백필)

---

## 참고사항
> - cron expression 기반 → 구조화된 컬럼 기반으로 변경되어 클라이언트/서비스 로직에서 반복 일정 처리 방식이 바뀜.
> - `state` 컬럼은 지난 회의에서 삭제하기로 하여 제거.