### PR TITLE
[Fix] routines V4에서 누락된 레거시 컬럼 제거 (V5 추가)

### DIFF
--- a/src/main/resources/db/migration/V5__cleanup_legacy_routine_columns.sql
+++ b/src/main/resources/db/migration/V5__cleanup_legacy_routine_columns.sql
@@ -1,0 +1,8 @@
+----------------------------------------
+-- routines 테이블 레거시 컬럼 정리
+-- V4에서 누락된 cron_expression, state 컬럼 제거
+----------------------------------------
+
+ALTER TABLE public.routines
+DROP COLUMN IF EXISTS cron_expression,
+    DROP COLUMN IF EXISTS state;


### PR DESCRIPTION
## 관련 이슈
- Refs #29 

---

## 작업 내용
- V4 마이그레이션이 `success: true`로 기록되었으나 `cron_expression`, `state` 컬럼이 실제로 제거되지 않은 이슈 발견
- V5 마이그레이션 추가하여 누락된 컬럼 제거
- `DROP COLUMN IF EXISTS` 사용하여 환경에 따른 안전성 확보

---

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] V5 마이그레이션 정상 실행 확인
- [x] `cron_expression`, `state` 컬럼 제거 확인
- [x] 기존 기능 정상 동작 확인

---

## 참고사항
> V4 마이그레이션 파일 자체는 정상 작성되었으나 일부 환경에서 컬럼 제거가 반영되지 않은 상태로 발견되어 V5로 보완.