### PR TITLE
[Feat] OpenAI 연동, 루틴 추천 후 추가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // ── AI ────────────────────────────────────────────────
-    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 
     // ── 개발 생산성 ────────────────────────────────────────
     compileOnly    'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // ── AI ────────────────────────────────────────────────
-    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
 
     // ── 개발 생산성 ────────────────────────────────────────
     compileOnly    'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai' //제미나이 스타터로 설정
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
     // ── Test ──────────────────────────────────────────────
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.ai:spring-ai-bom:1.0.0'
+        mavenBom 'org.springframework.ai:spring-ai-bom:1.1.4'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai' //제미나이 스타터로 설정
 
     // ── Test ──────────────────────────────────────────────
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -1,0 +1,22 @@
+package com.rutina.rutinabackend.domain.ailog.controller;
+
+import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
+import com.rutina.rutinabackend.domain.ailog.service.AiService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class AiController {
+
+    private final AiService aiService;
+
+    @PostMapping("/generate")
+    public ApiResponse<AiResponse> generate(@RequestBody AiRequest request) {
+        AiResponse response = aiService.generate(request);
+        return ApiResponse.ok("AI 응답 생성에 성공했습니다.", response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -1,22 +1,64 @@
 package com.rutina.rutinabackend.domain.ailog.controller;
 
-import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
-import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
+import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineAddRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineAddResponse;
+import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineOptionValuesResponse;
+import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineRecommendRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineRecommendResponse;
+//import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
+//import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
 import com.rutina.rutinabackend.domain.ailog.service.AiService;
 import com.rutina.rutinabackend.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/ai")
+@RequestMapping("/api/v1/ai-routines")
 @RequiredArgsConstructor
 public class AiController {
 
+    // 루틴 추천 조건 선택지 조회 API
     private final AiService aiService;
-
-    @PostMapping("/generate")
-    public ApiResponse<AiResponse> generate(@RequestBody AiRequest request) {
-        AiResponse response = aiService.generate(request);
-        return ApiResponse.ok("AI 응답 생성에 성공했습니다.", response);
+    @GetMapping("/options")
+    public ApiResponse<AiRoutineOptionValuesResponse> getOptions() {
+        return ApiResponse.ok(
+                "AI 루틴 선택지 조회에 성공했습니다.",
+                aiService.getOptions()
+        );
     }
+
+    // AI 루틴 추천 생성 API
+    @PostMapping("/recommend")
+    public ApiResponse<AiRoutineRecommendResponse> recommend(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody AiRoutineRecommendRequest request
+    ) {
+        return ApiResponse.ok(
+                "AI 루틴 추천에 성공했습니다.",
+                aiService.recommend(userDetails, request)
+        );
+    }
+
+    // AI 추천 루틴 중 사용자가 선택한 루틴만 추가하는 API
+    @PostMapping("/{recommendationId}/add")
+    public ApiResponse<AiRoutineAddResponse> addRecommendedRoutines(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long recommendationId,
+            @Valid @RequestBody AiRoutineAddRequest request
+    ) {
+        return ApiResponse.ok(
+                "선택한 루틴 추가에 성공했습니다.",
+                aiService.addRecommendedRoutines(userDetails, recommendationId, request)
+        );
+    }
+
+// 초기 코드 주석 처리
+//    @PostMapping("/generate")
+//    public ApiResponse<AiResponse> generate(@RequestBody AiRequest request) {
+//        AiResponse response = aiService.generate(request);
+//        return ApiResponse.ok("AI 응답 생성에 성공했습니다.", response);
+//    }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -18,10 +18,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/ai-routines")
 @RequiredArgsConstructor
+@Tag(name = "AI Routine", description = "AI 루틴 추천 API")
 public class AiController {
 
     // 루틴 추천 조건 선택지 조회 API
     private final AiService aiService;
+
+    @Operation(summary = "AI 루틴 추천 조건 선택지 조회")
     @GetMapping("/options")
     public ApiResponse<AiRoutineOptionValuesResponse> getOptions() {
         return ApiResponse.ok(
@@ -31,6 +34,7 @@ public class AiController {
     }
 
     // AI 루틴 추천 생성 API
+    @Operation(summary = "AI 루틴 추천 생성")
     @PostMapping("/recommend")
     public ApiResponse<AiRoutineRecommendResponse> recommend(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -43,6 +47,7 @@ public class AiController {
     }
 
     // AI 추천 루틴 중 사용자가 선택한 루틴만 추가하는 API
+    @Operation(summary = "선택한 AI 추천 루틴 추가")
     @PostMapping("/{recommendationId}/add")
     public ApiResponse<AiRoutineAddResponse> addRecommendedRoutines(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiRequest(
+        Long userId,
+        Long routineId,
+        String question
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRequest.java
@@ -2,7 +2,6 @@ package com.rutina.rutinabackend.domain.ailog.dto;
 
 public record AiRequest(
         Long userId,
-        Long routineId,
         String question
 ) {
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiResponse.java
@@ -1,0 +1,6 @@
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiResponse(
+        String response
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineAddRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineAddRequest.java
@@ -1,0 +1,15 @@
+// AI 추천 루틴 추가 요청 DTO
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record AiRoutineAddRequest(
+        Long categoryId,
+// 추천 요청 단계 또는 추가 요청 단계 중 한 곳에서만 받아오면 됨.
+
+        @NotEmpty(message = "추가할 루틴을 최소 1개 이상 선택해야 합니다.")
+        List<Integer> selectedOptionIds
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineAddResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineAddResponse.java
@@ -1,0 +1,7 @@
+// AI 추천 루틴 추가 DTO
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiRoutineAddResponse(
+        int addedCount
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineOption.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineOption.java
@@ -1,0 +1,10 @@
+// AI가 추천하는 후보 1개
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+public record AiRoutineOption(
+        Integer optionId,
+        String title,
+        String recommendedTime,
+        Integer durationMinutes
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineOptionValuesResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineOptionValuesResponse.java
@@ -1,0 +1,12 @@
+// AI 루틴 추천 조건 선택지 응답 DTO
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+import java.util.List;
+
+public record AiRoutineOptionValuesResponse(
+        List<String> purposes,
+        List<String> mainActivityTimes,
+        List<String> activityTypes,
+        List<String> hobbies
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutinePromptLog.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutinePromptLog.java
@@ -1,0 +1,19 @@
+// AiLog.prompt에 저장할 추천 요청 정보
+
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+import java.util.List;
+
+public record AiRoutinePromptLog(
+        Long userId,
+        String job,
+        String gender,
+        String age,
+        Long categoryId,
+        String categoryName,
+        String purpose,
+        String mainActivityTime,
+        String activityType,
+        List<String> hobbies
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendRequest.java
@@ -1,0 +1,23 @@
+// AI 루틴 추천 요청 DTO
+package com.rutina.rutinabackend.domain.ailog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record AiRoutineRecommendRequest(
+        Long categoryId,
+
+        @NotBlank(message = "목적은 필수입니다.")
+        String purpose,
+
+        @NotBlank(message = "주요 활동 시간은 필수입니다.")
+        String mainActivityTime,
+
+        String activityType,
+
+        @NotEmpty(message = "취미는 최소 1개 이상 선택해야 합니다.")
+        List<String> hobbies
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendResponse.java
@@ -1,0 +1,10 @@
+// AI 루틴 추천 응답 DTO
+package com.rutina.rutinabackend.domain.ailog.dto;
+import java.util.List;
+
+public record AiRoutineRecommendResponse(
+        Long recommendationId,
+        Long categoryId,
+        List<AiRoutineOption> routines
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendResult.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/dto/AiRoutineRecommendResult.java
@@ -1,0 +1,8 @@
+// AI 응답 파싱용
+package com.rutina.rutinabackend.domain.ailog.dto;
+import java.util.List;
+
+public record AiRoutineRecommendResult(
+        List<AiRoutineOption> routines
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AiLogRepository extends JpaRepository<AiLog, Long> {
-    List<AiLog> findByUserId(Long userId);
-    List<AiLog> findByRoutineId(Long routineId);
+    //기본적인 유저 조회
+    List<AiLog> findByUser_Id(Long userId);
+    //추가하기 버튼 눌렀을 때, 사용자가 선택한 optionId가 어떤 루틴 제목인지 알기 위함
+    Optional<AiLog> findByIdAndUser_Id(Long id, Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -17,10 +17,7 @@ import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
 @Service
 public class AiService {
@@ -217,11 +214,35 @@ public class AiService {
         }
     }
 
+    // 사용자의 기존 루틴 제목 목록 조회
+    private List<String> findExistingRoutineTitles(Long userId) {
+        return jdbcTemplate.query(
+                """
+                select title
+                  from routines
+                 where user_id = ?
+                 order by created_at desc
+                """,
+                (rs, rowNum) -> rs.getString("title"),
+                userId
+        );
+    }
+
+    // 기존 루틴 목록을 AI 프롬프트에 넣기 좋은 형태로 변환
+    private String formatExistingRoutines(List<String> existingRoutineTitles) {
+        if (existingRoutineTitles == null || existingRoutineTitles.isEmpty()) {
+            return "기존 루틴 없음";
+        }
+
+        return String.join(", ", existingRoutineTitles);
+    }
+
     // AI 프롬포트 생성
     private String buildRecommendPrompt(
             User user,
             AiRoutineRecommendRequest request,
             String categoryName,
+            List<String> existingRoutineTitles,
             String format
     ) {
         return """
@@ -241,6 +262,9 @@ public class AiService {
             활동 타입: %s
             취미: %s
 
+            [사용자의 기존 루틴 목록]
+            %s
+            
             [생성 규칙]
             - 루틴은 정확히 5개만 생성한다.
             - optionId는 1, 2, 3, 4, 5로 생성한다.
@@ -250,6 +274,11 @@ public class AiService {
             - durationMinutes는 5, 10, 15, 20, 30 중 하나만 사용한다.
             - 반복 여부는 만들지 않는다.
             - 사용자가 바로 추가할 수 있는 구체적인 루틴 제목으로 만든다.
+            - 기존 루틴과 제목이 같거나 의미가 거의 같은 루틴은 추천하지 않는다.
+            - 기존 루틴을 반복 추천하지 말고, 기존 루틴을 보완할 수 있는 루틴을 추천한다.
+            - 기존 루틴에 운동이 많으면 회복, 식단, 수면 같은 보완 루틴을 추천한다.
+            - 기존 루틴에 공부가 많으면 휴식, 정리, 복습, 집중 준비 루틴을 추천한다.
+            - 기존 루틴에 생활 관리가 많으면 꾸준함을 높이는 짧은 루틴을 추천한다.
 
             [응답 형식]
             %s
@@ -262,6 +291,7 @@ public class AiService {
                 request.mainActivityTime(),
                 normalizeBlank(request.activityType(), "선택 안 함"),
                 String.join(", ", request.hobbies()),
+                formatExistingRoutines(existingRoutineTitles),
                 format
         );
     }
@@ -293,6 +323,7 @@ public class AiService {
         validateRequestOptions(request);
 
         String categoryName = null; //협의 전까지 선택값으로 둠.
+        List<String> existingRoutineTitles = findExistingRoutineTitles(user.getId());
 
         // 추천 요청 단계에서 categoryId 들어오면 해당 카테고리가 유저의 카테고리인지 확인, 조회
         if (request.categoryId() != null) {
@@ -323,6 +354,7 @@ public class AiService {
                 user,
                 request,
                 categoryName,
+                existingRoutineTitles,
                 converter.getFormat()
         );
 
@@ -339,7 +371,7 @@ public class AiService {
                 .content();
 
         AiRoutineRecommendResult parsedResult = convertAiResult(converter, aiAnswer);
-        AiRoutineRecommendResult normalizedResult = normalizeResult(parsedResult);
+        AiRoutineRecommendResult normalizedResult = normalizeResult(parsedResult, existingRoutineTitles);
 
         /*
          * AiLog.prompt에는 추천 요청 당시의 사용자 정보와 선택 조건 저장
@@ -377,7 +409,10 @@ public class AiService {
      * - durationMinutes가 허용 목록에 없으면 10분
      */
 
-    private AiRoutineRecommendResult normalizeResult(AiRoutineRecommendResult result) {
+    private AiRoutineRecommendResult normalizeResult(
+            AiRoutineRecommendResult result,
+            List<String> existingRoutineTitles
+    ) {
         List<AiRoutineOption> routines = result.routines();
 
         if (routines == null || routines.size() < 5) {
@@ -389,28 +424,72 @@ public class AiService {
         }
 
         List<AiRoutineOption> normalized = new ArrayList<>();
+        List<String> usedTitles = new ArrayList<>();
 
-        for (int i = 0; i < 5; i++) {
-            AiRoutineOption option = routines.get(i);
+        for (AiRoutineOption option : routines) {
             String title = normalizeTitle(option.title());
 
             if (title.isBlank()) {
-                throw new BusinessException(
-                        HttpStatus.INTERNAL_SERVER_ERROR,
-                        "AI_RESPONSE_TITLE_INVALID",
-                        "AI 추천 루틴 제목이 올바르지 않습니다."
-                );
+                continue;
+            }
+
+            if (isDuplicateTitle(title, existingRoutineTitles)) {
+                continue;
+            }
+
+            if (isDuplicateTitle(title, usedTitles)) {
+                continue;
             }
 
             normalized.add(new AiRoutineOption(
-                    i + 1,
+                    normalized.size() + 1,
                     title,
                     normalizeBlank(option.recommendedTime(), "미정"),
                     normalizeDuration(option.durationMinutes())
             ));
+
+            usedTitles.add(title);
+
+            if (normalized.size() == 5) {
+                break;
+            }
+        }
+
+        if (normalized.size() < 5) {
+            throw new BusinessException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "AI_RESPONSE_UNIQUE_COUNT_INVALID",
+                    "기존 루틴과 겹치지 않는 추천 결과가 5개 미만입니다. 다시 추천을 요청해주세요."
+            );
         }
 
         return new AiRoutineRecommendResult(normalized);
+    }
+
+    // 기존 루틴 또는 추천 목록 내부에서 제목이 겹치는지 검사
+    private boolean isDuplicateTitle(String title, List<String> titles) {
+        if (title == null || titles == null || titles.isEmpty()) {
+            return false;
+        }
+
+        String normalizedTitle = normalizeForCompare(title);
+
+        return titles.stream()
+                .filter(Objects::nonNull)
+                .map(this::normalizeForCompare)
+                .anyMatch(existingTitle -> existingTitle.equals(normalizedTitle));
+    }
+
+    // 제목 비교용 정규화
+    private String normalizeForCompare(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replaceAll("\\s+", "")
+                .replaceAll("[^가-힣a-zA-Z0-9]", "")
+                .toLowerCase();
     }
 
     // AiLog.prompt에 저장할 추천 요청 정보 생성
@@ -609,8 +688,10 @@ public class AiService {
                 );
             }
 
-            insertRoutine(user.getId(), categoryId, option.title());
-            addedCount++;
+            if (!existsRoutineTitle(user.getId(), option.title())) {
+                insertRoutine(user.getId(), categoryId, option.title());
+                addedCount++;
+            }
         }
 
         return new AiRoutineAddResponse(addedCount);
@@ -644,9 +725,27 @@ public class AiService {
         );
     }
 
-    /**
-     * 선택한 카테고리가 현재 로그인한 유저의 카테고리인지 검증
-     */
+    // 사용자의 기존 루틴에 같은 제목이 있는지 확인
+    private boolean existsRoutineTitle(Long userId, String title) {
+        Boolean exists = jdbcTemplate.queryForObject(
+                """
+                select exists(
+                    select 1
+                      from routines
+                     where user_id = ?
+                       and regexp_replace(lower(title), '[^가-힣a-z0-9]', '', 'g')
+                           = regexp_replace(lower(?), '[^가-힣a-z0-9]', '', 'g')
+                )
+                """,
+                Boolean.class,
+                userId,
+                title
+        );
+
+        return exists != null && exists;
+    }
+
+    // 선택한 카테고리가 현재 로그인한 유저의 카테고리인지 검증
     private void validateCategoryOwnership(Long userId, Long categoryId) {
         Boolean exists = jdbcTemplate.queryForObject(
                 "select exists(select 1 from categories where id = ? and user_id = ?)",
@@ -664,11 +763,7 @@ public class AiService {
         }
     }
 
-    /**
-     * 선택된 추천 루틴을 routines 테이블에 추가
-     *
-     * 반복은 기본적으로 하지 않으므로 cron_expression은 null로 저장한다.
-     */
+    // 선택된 추천 루틴을 routines 테이블에 추가
     private void insertRoutine(Long userId, Long categoryId, String title) {
         jdbcTemplate.update("""
             insert into routines

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -12,7 +12,13 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 @Service
 public class AiService {
     // 나중에 AI 기능이 여러 개로 늘어났을 때, 루틴 추천 로그만 구분하기 위해 사용한다.
@@ -208,8 +214,336 @@ public class AiService {
         }
     }
 
-    public AiRoutineRecommendResponse recommend(UserDetails userDetails, AiRoutineRecommendRequest request) {
-        throw new UnsupportedOperationException("AI 루틴 추천 기능 구현 전");
+    // AI 프롬포트 생성
+    private String buildRecommendPrompt(
+            User user,
+            AiRoutineRecommendRequest request,
+            String categoryName,
+            String format
+    ) {
+        return """
+            아래 정보를 바탕으로 루틴 후보 5개를 추천해라.
+
+            [사용자 정보]
+            직업: %s
+            성별: %s
+            나이대: %s
+
+            [선택한 카테고리]
+            카테고리: %s
+
+            [사용자 선택값]
+            목적: %s
+            주요 활동 시간: %s
+            활동 타입: %s
+            취미: %s
+
+            [생성 규칙]
+            - 루틴은 정확히 5개만 생성한다.
+            - optionId는 1, 2, 3, 4, 5로 생성한다.
+            - title은 30자 이하로 작성한다.
+            - description은 생성하지 않는다.
+            - recommendedTime은 사용자의 주요 활동 시간과 어울리게 작성한다.
+            - durationMinutes는 5, 10, 15, 20, 30 중 하나만 사용한다.
+            - 반복 여부는 만들지 않는다.
+            - 사용자가 바로 추가할 수 있는 구체적인 루틴 제목으로 만든다.
+
+            [응답 형식]
+            %s
+            """.formatted(
+                user.getJob(),
+                convertGender(user.getGender()),
+                String.valueOf(user.getAge()),
+                normalizeBlank(categoryName, "선택 안 함"),
+                request.purpose(),
+                request.mainActivityTime(),
+                normalizeBlank(request.activityType(), "선택 안 함"),
+                String.join(", ", request.hobbies()),
+                format
+        );
+    }
+
+    /**
+     * AI 루틴 추천 생성
+     *
+     * 처리 흐름:
+     * 1. 로그인 유저 조회
+     * 2. 유저 테이블의 직업, 성별, 나이대 검증
+     * 3. 사용자가 선택한 목적, 주요 활동 시간, 활동 타입, 취미 검증
+     * 4. categoryId가 있으면 본인 카테고리인지 확인하고 카테고리명 조회
+     * 5. OpenAI에 전달할 프롬프트 생성
+     * 6. OpenAI 호출
+     * 7. AI 응답을 DTO로 변환
+     * 8. 추천 결과를 5개로 정리
+     * 9. AiLog에 요청 정보와 추천 결과 저장
+     * 10. recommendationId와 루틴 후보 5개 반환
+     */
+
+    @Transactional
+    public AiRoutineRecommendResponse recommend(
+            UserDetails userDetails,
+            AiRoutineRecommendRequest request
+    ) {
+        User user = getLoginUser(userDetails);
+
+        validateUserInfo(user);
+        validateRequestOptions(request);
+
+        String categoryName = null; //협의 전까지 선택값으로 둠.
+
+        // 추천 요청 단계에서 categoryId 들어오면 해당 카테고리가 유저의 카테고리인지 확인, 조회
+        if (request.categoryId() != null) {
+            categoryName = findCategoryName(user.getId(), request.categoryId());
+        }
+
+        /*
+         * AI 응답을 지정한 DTO 형태로 변환하기 위해 사용한다.
+         *
+         * 최종적인 AI 응답 구조
+         *
+         * {
+         *   "routines": [
+         *     {
+         *       "optionId": 1,
+         *       "title": "아침 물 한 잔 마시기",
+         *       "recommendedTime": "아침",
+         *       "durationMinutes": 5
+         *     }
+         *   ]
+         * }
+         */
+
+        BeanOutputConverter<AiRoutineRecommendResult> converter =
+                new BeanOutputConverter<>(AiRoutineRecommendResult.class);
+
+        String prompt = buildRecommendPrompt(
+                user,
+                request,
+                categoryName,
+                converter.getFormat()
+        );
+
+        String aiAnswer = chatClient.prompt()
+                .system("""
+                    너는 루틴 추천 앱 Rutina의 AI 루틴 추천 엔진이다.
+                    사용자의 직업, 성별, 나이대와 선택 조건을 바탕으로 루틴 후보를 추천한다.
+                    설명(description)은 절대 생성하지 않는다.
+                    반복 설정은 생성하지 않는다.
+                    사용자가 실제 앱에 추가할 수 있는 루틴 제목만 추천한다.
+                    """)
+                .user(prompt)
+                .call()
+                .content();
+
+        AiRoutineRecommendResult parsedResult = convertAiResult(converter, aiAnswer);
+        AiRoutineRecommendResult normalizedResult = normalizeResult(parsedResult);
+
+        /*
+         * AiLog.prompt에는 추천 요청 당시의 사용자 정보와 선택 조건 저장
+         * AiLog.response에는 AI 추천 결과 5개 저장
+         */
+
+        AiRoutinePromptLog promptLog = createPromptLog(user, request, categoryName);
+
+        AiLog aiLog = AiLog.create(
+                user,
+                null,
+                REQUEST_TYPE_ROUTINE_RECOMMEND,
+                toJson(promptLog),
+                toJson(normalizedResult)
+        );
+
+        aiLogRepository.save(aiLog);
+
+        return new AiRoutineRecommendResponse(
+                aiLog.getId(),
+                request.categoryId(),
+                normalizedResult.routines()
+        );
+    }
+
+    /**
+     * AI 추천 결과 정리
+     *
+     * 보정 내용:
+     * - 추천 결과가 5개 미만이면 예외
+     * - 5개보다 많으면 앞에서 5개만 사용
+     * - optionId는 서버에서 1~5로 다시 부여
+     * - title은 30자 제한
+     * - recommendedTime이 비어 있으면 "미정"
+     * - durationMinutes가 허용 목록에 없으면 10분
+     */
+
+    private AiRoutineRecommendResult normalizeResult(AiRoutineRecommendResult result) {
+        List<AiRoutineOption> routines = result.routines();
+
+        if (routines == null || routines.size() < 5) {
+            throw new BusinessException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "AI_RESPONSE_COUNT_INVALID",
+                    "AI 추천 결과는 5개여야 합니다."
+            );
+        }
+
+        List<AiRoutineOption> normalized = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            AiRoutineOption option = routines.get(i);
+            String title = normalizeTitle(option.title());
+
+            if (title.isBlank()) {
+                throw new BusinessException(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "AI_RESPONSE_TITLE_INVALID",
+                        "AI 추천 루틴 제목이 올바르지 않습니다."
+                );
+            }
+
+            normalized.add(new AiRoutineOption(
+                    i + 1,
+                    title,
+                    normalizeBlank(option.recommendedTime(), "미정"),
+                    normalizeDuration(option.durationMinutes())
+            ));
+        }
+
+        return new AiRoutineRecommendResult(normalized);
+    }
+
+    // AiLog.prompt에 저장할 추천 요청 정보 생성
+    private AiRoutinePromptLog createPromptLog(
+            User user,
+            AiRoutineRecommendRequest request,
+            String categoryName
+    ) {
+        return new AiRoutinePromptLog(
+                user.getId(),
+                user.getJob(),
+                convertGender(user.getGender()),
+                String.valueOf(user.getAge()),
+                request.categoryId(),
+                categoryName,
+                request.purpose(),
+                request.mainActivityTime(),
+                normalizeBlank(request.activityType(), "선택 안 함"),
+                request.hobbies()
+        );
+    }
+
+    // categoryId로 카테고리명 조회
+    private String findCategoryName(Long userId, Long categoryId) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "select name from categories where id = ? and user_id = ?",
+                    String.class,
+                    categoryId,
+                    userId
+            );
+        } catch (EmptyResultDataAccessException e) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_CATEGORY",
+                    "본인의 카테고리만 선택할 수 있습니다."
+            );
+        }
+    }
+
+    // 성별 값 문자열 변환
+    // gender가 숫자인 경우: 0 → 남성 / 1 → 여성 / 2 → 기타
+
+    private String convertGender(Object gender) {
+        if (gender == null) {
+            return "미입력";
+        }
+
+        if (gender instanceof Number number) {
+            return switch (number.intValue()) {
+                case 0 -> "남성";
+                case 1 -> "여성";
+                case 2 -> "기타";
+                default -> "미입력";
+            };
+        }
+
+        String value = gender.toString().trim();
+
+        if (value.isBlank()) {
+            return "미입력";
+        }
+
+        return value;
+    }
+
+    // 루틴 제목 길이 제한 정리
+    private String normalizeTitle(String title) {
+        if (title == null) {
+            return "";
+        }
+
+        String normalized = title.trim();
+
+        if (normalized.length() > 30) {
+            return normalized.substring(0, 30);
+        }
+
+        return normalized;
+    }
+
+    // null 또는 빈 문자열이면 기본값으로 대체
+    private String normalizeBlank(String value, String defaultValue) {
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+
+        return value.trim();
+    }
+
+    // 추천 소요 시간 정리: AI가 이상한 값 내려 주면 그 값 보정
+    private Integer normalizeDuration(Integer durationMinutes) {
+        if (durationMinutes == null) {
+            return 10;
+        }
+
+        if (!ALLOWED_DURATIONS.contains(durationMinutes)) {
+            return 10;
+        }
+
+        return durationMinutes;
+    }
+    // AI 응답 문자열을 AiRoutineRecommendResult DTO로 변환
+    private AiRoutineRecommendResult convertAiResult(
+            BeanOutputConverter<AiRoutineRecommendResult> converter,
+            String aiAnswer
+    ) {
+        try {
+            AiRoutineRecommendResult result = converter.convert(aiAnswer);
+
+            if (result == null || result.routines() == null) {
+                throw new IllegalStateException("AI 응답이 비어 있습니다.");
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new BusinessException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "AI_RESPONSE_PARSE_FAILED",
+                    "AI 추천 결과 변환에 실패했습니다."
+            );
+        }
+    }
+
+    // 객체를 JSON 문자열로 변환
+    // AiLog.prompt, AiLog.response 저장 시 사용
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "JSON_CONVERT_FAILED",
+                    "JSON 변환에 실패했습니다."
+            );
+        }
     }
 
     public AiRoutineAddResponse addRecommendedRoutines(

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -2,36 +2,41 @@ package com.rutina.rutinabackend.domain.ailog.service;
 
 import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
 import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
-import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
-import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+//import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+//import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.BusinessException;
-import com.rutina.rutinabackend.global.exception.ErrorCode;
+//import com.rutina.rutinabackend.global.exception.ErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 
 @Service
 public class AiService {
 
     private final ChatClient chatClient;
     private final UserRepository userRepository;
-    private final AiLogRepository aiLogRepository;
+//    private final AiLogRepository aiLogRepository;
 
     public AiService(
             ChatClient.Builder chatClientBuilder,
-            UserRepository userRepository,
-            AiLogRepository aiLogRepository
+            UserRepository userRepository
+//            AiLogRepository aiLogRepository
     ) {
         this.chatClient = chatClientBuilder.build();
         this.userRepository = userRepository;
-        this.aiLogRepository = aiLogRepository;
+//        this.aiLogRepository = aiLogRepository;
     }
 
     //간단하게 임시 프롬포트 작성해 둠
     public AiResponse generate(AiRequest request) {
         User user = userRepository.findById(request.userId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.NOT_FOUND,
+                        "USER_NOT_FOUND",
+                        "사용자를 찾을 수 없습니다."
+                ));
 
         validateUserInfo(user);
 
@@ -54,15 +59,15 @@ public class AiService {
                 .call()
                 .content();
 
-        AiLog aiLog = AiLog.builder()
-                .userId(user.getId())
-                .routineId(request.routineId())
-                .requestType("ROUTINE_RECOMMEND")
-                .prompt(prompt)
-                .response(result)
-                .build();
-
-        aiLogRepository.save(aiLog);
+//        AiLog aiLog = AiLog.builder()
+//                .userId(user.getId())
+//                .routineId(request.routineId())
+//                .requestType("ROUTINE_RECOMMEND")
+//                .prompt(prompt)
+//                .response(result)
+//                .build();
+//
+//        aiLogRepository.save(aiLog);
 
         return new AiResponse(result);
     }
@@ -72,9 +77,11 @@ public class AiService {
         boolean missingAge = user.getAge() == null;
         boolean missingGender = user.getGender() == null;
 
-        if (missingRole || missingAge || missingGender) {
-            throw new BusinessException(ErrorCode.AI_PROFILE_INFO_REQUIRED);
-        }
+        throw new BusinessException(
+                HttpStatus.BAD_REQUEST,
+                "AI_PROFILE_INFO_REQUIRED",
+                "직업, 연령, 성별 정보를 입력해야 이용 가능한 서비스입니다."
+        );
     }
 
     private String convertGender(Integer gender) {

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -1,0 +1,88 @@
+package com.rutina.rutinabackend.domain.ailog.service;
+
+import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
+import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
+import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.BusinessException;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiService {
+
+    private final ChatClient chatClient;
+    private final UserRepository userRepository;
+    private final AiLogRepository aiLogRepository;
+
+    public AiService(
+            ChatClient.Builder chatClientBuilder,
+            UserRepository userRepository,
+            AiLogRepository aiLogRepository
+    ) {
+        this.chatClient = chatClientBuilder.build();
+        this.userRepository = userRepository;
+        this.aiLogRepository = aiLogRepository;
+    }
+
+    //간단하게 임시 프롬포트 작성해 둠
+    public AiResponse generate(AiRequest request) {
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        validateUserInfo(user);
+
+        String prompt = """
+                사용자 정보입니다.
+                
+                닉네임: %s
+                직업: %s
+                연령: %s
+                성별: %s
+                """.formatted(
+                user.getNickname(),
+                user.getRole(),
+                user.getAge(),
+                convertGender(user.getGender())
+        );
+
+        String result = chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content();
+
+        AiLog aiLog = AiLog.builder()
+                .userId(user.getId())
+                .routineId(request.routineId())
+                .requestType("ROUTINE_RECOMMEND")
+                .prompt(prompt)
+                .response(result)
+                .build();
+
+        aiLogRepository.save(aiLog);
+
+        return new AiResponse(result);
+    }
+
+    private void validateUserInfo(User user) {
+        boolean missingRole = user.getRole() == null || user.getRole().isBlank();
+        boolean missingAge = user.getAge() == null;
+        boolean missingGender = user.getGender() == null;
+
+        if (missingRole || missingAge || missingGender) {
+            throw new BusinessException(ErrorCode.AI_PROFILE_INFO_REQUIRED);
+        }
+    }
+
+    private String convertGender(Integer gender) {
+        return switch (gender) {
+            case 0 -> "남성";
+            case 1 -> "여성";
+            case 2 -> "기타";
+            default -> "미입력";
+        };
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -68,7 +68,7 @@ public class AiService {
     );
 
     // AI가 추천할 수 있는 루틴 소요 시간 목록
-    private static final List<Integer> ALLOWED_DURATIONS = List.of(5, 10, 15, 20, 30);
+    private static final List<Integer> ALLOWED_DURATIONS = List.of(10, 20, 30, 40, 50, 60);
 
     // 의존성 주입 필드
 
@@ -271,7 +271,8 @@ public class AiService {
             - title은 30자 이하로 작성한다.
             - description은 생성하지 않는다.
             - recommendedTime은 사용자의 주요 활동 시간과 어울리게 작성한다.
-            - durationMinutes는 5, 10, 15, 20, 30 중 하나만 사용한다.
+            - durationMinutes는 10, 20, 30, 40, 50, 60 중 하나만 사용한다.
+            - durationMinutes는 루틴 수행 시간이며 최대 60분을 넘기지 않는다.
             - 반복 여부는 만들지 않는다.
             - 사용자가 바로 추가할 수 있는 구체적인 루틴 제목으로 만든다.
             - 기존 루틴과 제목이 같거나 의미가 거의 같은 루틴은 추천하지 않는다.
@@ -767,14 +768,26 @@ public class AiService {
     private void insertRoutine(Long userId, Long categoryId, String title) {
         jdbcTemplate.update("""
             insert into routines
-            (user_id, category_id, title, alarm, state, cron_expression, start_time, end_time, created_at, updated_at)
-            values (?, ?, ?, ?, ?, ?, ?, ?, now(), now())
+            (
+                user_id,
+                category_id,
+                title,
+                alarm,
+                repeat_type,
+                repeat_interval,
+                repeat_unit,
+                repeat_days,
+                start_at,
+                created_at,
+                updated_at
+            )
+            values (?, ?, ?, ?, ?, ?, ?, ?, current_date, now(), now())
             """,
                 userId,
                 categoryId,
                 title,
                 false,
-                true,
+                "NONE",
                 null,
                 null,
                 null

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -19,6 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 public class AiService {
     // 나중에 AI 기능이 여러 개로 늘어났을 때, 루틴 추천 로그만 구분하기 위해 사용한다.
@@ -546,11 +549,157 @@ public class AiService {
         }
     }
 
+    /**
+     * 사용자가 체크한 AI 추천 루틴을 실제 routines 테이블에 추가
+     *
+     * 처리 흐름:
+     * 1. 로그인 유저 조회
+     * 2. recommendationId로 AiLog 조회
+     * 3. categoryId 결정
+     *    - 추가 요청의 categoryId 우선 사용
+     *    - 없으면 추천 요청 당시 AiLog.prompt에 저장된 categoryId 사용
+     *    - 둘 다 없으면 예외 발생
+     * 4. AiLog.response에서 AI 추천 루틴 5개 복원
+     * 5. 사용자가 체크한 optionId만 찾아 routines 테이블에 insert
+     */
+    @Transactional
     public AiRoutineAddResponse addRecommendedRoutines(
             UserDetails userDetails,
             Long recommendationId,
             AiRoutineAddRequest request
     ) {
-        throw new UnsupportedOperationException("AI 추천 루틴 추가 기능 구현 전");
+        User user = getLoginUser(userDetails);
+
+        AiLog aiLog = aiLogRepository.findByIdAndUser_Id(recommendationId, user.getId())
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.NOT_FOUND,
+                        "AI_RECOMMENDATION_NOT_FOUND",
+                        "AI 추천 기록을 찾을 수 없습니다."
+                ));
+
+        Long categoryId = resolveCategoryId(user.getId(), request.categoryId(), aiLog);
+
+        AiRoutineRecommendResult result = fromJson(aiLog.getResponse(), AiRoutineRecommendResult.class);
+
+        Map<Integer, AiRoutineOption> optionMap = result.routines().stream()
+                .collect(Collectors.toMap(AiRoutineOption::optionId, option -> option));
+
+        List<Integer> selectedOptionIds = request.selectedOptionIds().stream()
+                .distinct()
+                .toList();
+
+        if (selectedOptionIds.isEmpty()) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "AI_ROUTINE_SELECTION_REQUIRED",
+                    "추가할 루틴을 최소 1개 이상 선택해야 합니다."
+            );
+        }
+
+        int addedCount = 0;
+
+        for (Integer optionId : selectedOptionIds) {
+            AiRoutineOption option = optionMap.get(optionId);
+
+            if (option == null) {
+                throw new BusinessException(
+                        HttpStatus.BAD_REQUEST,
+                        "INVALID_AI_ROUTINE_OPTION",
+                        "존재하지 않는 추천 루틴입니다."
+                );
+            }
+
+            insertRoutine(user.getId(), categoryId, option.title());
+            addedCount++;
+        }
+
+        return new AiRoutineAddResponse(addedCount);
+    }
+
+    /**
+     * routines insert에 사용할 categoryId 결정
+     *
+     * 우선순위:
+     * 1. 추가 요청 body의 categoryId
+     * 2. 추천 요청 당시 AiLog.prompt에 저장된 categoryId
+     * 3. 둘 다 없으면 예외
+     */
+    private Long resolveCategoryId(Long userId, Long requestCategoryId, AiLog aiLog) {
+        if (requestCategoryId != null) {
+            validateCategoryOwnership(userId, requestCategoryId);
+            return requestCategoryId;
+        }
+
+        AiRoutinePromptLog promptLog = fromJson(aiLog.getPrompt(), AiRoutinePromptLog.class);
+
+        if (promptLog.categoryId() != null) {
+            validateCategoryOwnership(userId, promptLog.categoryId());
+            return promptLog.categoryId();
+        }
+
+        throw new BusinessException(
+                HttpStatus.BAD_REQUEST,
+                "CATEGORY_REQUIRED",
+                "루틴을 추가하려면 카테고리를 선택해야 합니다."
+        );
+    }
+
+    /**
+     * 선택한 카테고리가 현재 로그인한 유저의 카테고리인지 검증
+     */
+    private void validateCategoryOwnership(Long userId, Long categoryId) {
+        Boolean exists = jdbcTemplate.queryForObject(
+                "select exists(select 1 from categories where id = ? and user_id = ?)",
+                Boolean.class,
+                categoryId,
+                userId
+        );
+
+        if (exists == null || !exists) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_CATEGORY",
+                    "본인의 카테고리만 선택할 수 있습니다."
+            );
+        }
+    }
+
+    /**
+     * 선택된 추천 루틴을 routines 테이블에 추가
+     *
+     * 반복은 기본적으로 하지 않으므로 cron_expression은 null로 저장한다.
+     */
+    private void insertRoutine(Long userId, Long categoryId, String title) {
+        jdbcTemplate.update("""
+            insert into routines
+            (user_id, category_id, title, alarm, state, cron_expression, start_time, end_time, created_at, updated_at)
+            values (?, ?, ?, ?, ?, ?, ?, ?, now(), now())
+            """,
+                userId,
+                categoryId,
+                title,
+                false,
+                true,
+                null,
+                null,
+                null
+        );
+    }
+
+    /**
+     * JSON 문자열을 객체로 변환
+     *
+     * AiLog.prompt, AiLog.response를 다시 DTO로 복원할 때 사용한다.
+     */
+    private <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "JSON_PARSE_FAILED",
+                    "JSON 파싱에 실패했습니다."
+            );
+        }
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -18,6 +18,7 @@ import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class AiService {

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -1,95 +1,222 @@
 package com.rutina.rutinabackend.domain.ailog.service;
 
-import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
-import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
-//import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
-//import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rutina.rutinabackend.domain.ailog.dto.*;
+import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.BusinessException;
-//import com.rutina.rutinabackend.global.exception.ErrorCode;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
 
 @Service
 public class AiService {
+    // 나중에 AI 기능이 여러 개로 늘어났을 때, 루틴 추천 로그만 구분하기 위해 사용한다.
+    private static final String REQUEST_TYPE_ROUTINE_RECOMMEND = "ROUTINE_RECOMMEND";
 
-    private final ChatClient chatClient;
-    private final UserRepository userRepository;
-//    private final AiLogRepository aiLogRepository;
+    // 프론트에서 자유 입력 거부하고, 하단 선택지에서만 고르게 하기 위한 목록(임시)
+    private static final List<String> PURPOSES = List.of(
+            "건강 관리",
+            "자기계발",
+            "공부/집중",
+            "생활 습관 개선",
+            "취미 관리"
+    );
+
+    // 목적
+    private static final List<String> MAIN_ACTIVITY_TIMES = List.of(
+            "아침",
+            "오전",
+            "오후",
+            "저녁",
+            "밤"
+    );
+
+    // 루틴 활동 타입
+    private static final List<String> ACTIVITY_TYPES = List.of(
+            "실내 활동",
+            "야외 활동",
+            "정적인 활동",
+            "동적인 활동",
+            "혼자 하는 활동",
+            "함께 하는 활동"
+    );
+
+    // 취미
+    private static final List<String> HOBBIES = List.of(
+            "독서",
+            "운동",
+            "음악",
+            "영화/드라마",
+            "게임",
+            "요리",
+            "산책",
+            "일기",
+            "공부",
+            "청소/정리",
+            "없음"
+    );
+
+    // AI가 추천할 수 있는 루틴 소요 시간 목록
+    private static final List<Integer> ALLOWED_DURATIONS = List.of(5, 10, 15, 20, 30);
+
+    // 의존성 주입 필드
+
+    private final ChatClient chatClient; //OpenAI 호출용
+    private final UserRepository userRepository; //로그인 유저 조회용
+    private final AiLogRepository aiLogRepository; //AI 추천 결과 저장/조회용
+    private final JdbcTemplate jdbcTemplate; //카테고리 검증, 루틴 insert 등 직접 SQL 처리용
+    private final ObjectMapper objectMapper; //prompt/response JSON 변환용
 
     public AiService(
             ChatClient.Builder chatClientBuilder,
-            UserRepository userRepository
-//            AiLogRepository aiLogRepository
+            UserRepository userRepository,
+            AiLogRepository aiLogRepository,
+            JdbcTemplate jdbcTemplate,
+            ObjectMapper objectMapper
     ) {
         this.chatClient = chatClientBuilder.build();
         this.userRepository = userRepository;
-//        this.aiLogRepository = aiLogRepository;
+        this.aiLogRepository = aiLogRepository;
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
     }
 
-    //간단하게 임시 프롬포트 작성해 둠
-    public AiResponse generate(AiRequest request) {
-        User user = userRepository.findById(request.userId())
-                .orElseThrow(() -> new BusinessException(
-                        HttpStatus.NOT_FOUND,
-                        "USER_NOT_FOUND",
-                        "사용자를 찾을 수 없습니다."
-                ));
-
-        validateUserInfo(user);
-
-        String prompt = """
-                사용자 정보입니다.
-                
-                닉네임: %s
-                직업: %s
-                연령: %s
-                성별: %s
-                """.formatted(
-                user.getNickname(),
-                user.getRole(),
-                user.getAge(),
-                convertGender(user.getGender())
+    // AI 추천 조건 선택지 조회
+    public AiRoutineOptionValuesResponse getOptions() {
+        return new AiRoutineOptionValuesResponse(
+                PURPOSES,
+                MAIN_ACTIVITY_TIMES,
+                ACTIVITY_TYPES,
+                HOBBIES
         );
-
-        String result = chatClient.prompt()
-                .user(prompt)
-                .call()
-                .content();
-
-//        AiLog aiLog = AiLog.builder()
-//                .userId(user.getId())
-//                .routineId(request.routineId())
-//                .requestType("ROUTINE_RECOMMEND")
-//                .prompt(prompt)
-//                .response(result)
-//                .build();
-//
-//        aiLogRepository.save(aiLog);
-
-        return new AiResponse(result);
     }
 
+    // 현재 로그인한 사용자 조회
+    private User getLoginUser(UserDetails userDetails) {
+        if (userDetails == null || userDetails.getUsername() == null) {
+            throw new BusinessException(
+                    HttpStatus.UNAUTHORIZED,
+                    "UNAUTHORIZED",
+                    "로그인이 필요합니다."
+            );
+        }
+
+        String username = userDetails.getUsername();
+
+        try {
+            Long userId = Long.valueOf(username);
+
+            return userRepository.findById(userId)
+                    .orElseThrow(() -> new BusinessException(
+                            HttpStatus.NOT_FOUND,
+                            "USER_NOT_FOUND",
+                            "사용자를 찾을 수 없습니다."
+                    ));
+        } catch (NumberFormatException ignored) {
+            Long userId = findUserIdByEmail(username);
+
+            return userRepository.findById(userId)
+                    .orElseThrow(() -> new BusinessException(
+                            HttpStatus.NOT_FOUND,
+                            "USER_NOT_FOUND",
+                            "사용자를 찾을 수 없습니다."
+                    ));
+        }
+    }
+
+    // UserDetails.username이 email인 경우 users 테이블에서 id 조회
+    private Long findUserIdByEmail(String email) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "select id from users where email = ?",
+                    Long.class,
+                    email
+            );
+        } catch (EmptyResultDataAccessException e) {
+            throw new BusinessException(
+                    HttpStatus.NOT_FOUND,
+                    "USER_NOT_FOUND",
+                    "사용자를 찾을 수 없습니다."
+            );
+        }
+    }
+
+    // AI 추천에 필요한 사용자 정보 검증
     private void validateUserInfo(User user) {
-        boolean missingRole = user.getRole() == null || user.getRole().isBlank();
+        boolean missingJob = user.getJob() == null || user.getJob().isBlank();
         boolean missingAge = user.getAge() == null;
         boolean missingGender = user.getGender() == null;
 
-        throw new BusinessException(
-                HttpStatus.BAD_REQUEST,
-                "AI_PROFILE_INFO_REQUIRED",
-                "직업, 연령, 성별 정보를 입력해야 이용 가능한 서비스입니다."
-        );
+        if (missingJob || missingAge || missingGender) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "AI_PROFILE_INFO_REQUIRED",
+                    "직업, 연령, 성별 정보를 입력해야 이용 가능한 서비스입니다."
+            );
+        }
     }
 
-    private String convertGender(Integer gender) {
-        return switch (gender) {
-            case 0 -> "남성";
-            case 1 -> "여성";
-            case 2 -> "기타";
-            default -> "미입력";
-        };
+    // 프론트 선택값 검증
+    private void validateRequestOptions(AiRoutineRecommendRequest request) {
+        if (!PURPOSES.contains(request.purpose())) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_PURPOSE",
+                    "허용되지 않은 목적입니다."
+            );
+        }
+
+        if (!MAIN_ACTIVITY_TIMES.contains(request.mainActivityTime())) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_MAIN_ACTIVITY_TIME",
+                    "허용되지 않은 주요 활동 시간입니다."
+            );
+        }
+
+        if (request.activityType() != null
+                && !request.activityType().isBlank()
+                && !ACTIVITY_TYPES.contains(request.activityType())) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_ACTIVITY_TYPE",
+                    "허용되지 않은 활동 타입입니다."
+            );
+        }
+
+        if (request.hobbies() == null || request.hobbies().isEmpty()) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST,
+                    "INVALID_HOBBY",
+                    "취미는 최소 1개 이상 선택해야 합니다."
+            );
+        }
+
+        for (String hobby : request.hobbies()) {
+            if (!HOBBIES.contains(hobby)) {
+                throw new BusinessException(
+                        HttpStatus.BAD_REQUEST,
+                        "INVALID_HOBBY",
+                        "허용되지 않은 취미입니다."
+                );
+            }
+        }
+    }
+
+    public AiRoutineRecommendResponse recommend(UserDetails userDetails, AiRoutineRecommendRequest request) {
+        throw new UnsupportedOperationException("AI 루틴 추천 기능 구현 전");
+    }
+
+    public AiRoutineAddResponse addRecommendedRoutines(
+            UserDetails userDetails,
+            Long recommendationId,
+            AiRoutineAddRequest request
+    ) {
+        throw new UnsupportedOperationException("AI 추천 루틴 추가 기능 구현 전");
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -32,6 +32,9 @@ public class User {
 
     private Integer gender;
 
+    @Column(name = "job")
+    private String job;
+
     @Column(nullable = false)
     private String provider;
 

--- a/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/rutina/rutinabackend/global/config/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
     // 인증 없이 접근 가능한 엔드포인트
     private static final String[] PUBLIC_URLS = {
             "/api/v1/auth/**",
+            "/api/ai/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,14 +14,24 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 # 제미나이 사용
-  ai:
-    google:
-      genai:
-        api-key: ${GEMINI_API_KEY}
-        chat:
-          options:
-            model: gemini-2.5-flash
+#  ai:
+#    google:
+#      genai:
+#        api-key: ${OPENAI_API_KEY}
+#        chat:
+#          options:
+#            model: gemini-2.5-flash
 
+# OpenAI 사용
+  ai:
+    model:
+      chat: openai
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 0.7
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,10 +13,14 @@ spring:
       ddl-auto: update
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
-# ai 연결 안 해서 일단 임시값
+# 제미나이 사용
   ai:
-    openai:
-      api-key: "dummy"
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY}
+        chat:
+          options:
+            model: gemini-2.5-flash
 
   autoconfigure:
     exclude:

--- a/tatus
+++ b/tatus
@@ -1,0 +1,53 @@
+[1mdiff --git a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java[m
+[1mindex 8800f8b..9490c33 100644[m
+[1m--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java[m
+[1m+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java[m
+[36m@@ -68,7 +68,7 @@[m [mpublic class AiService {[m
+     );[m
+ [m
+     // AI가 추천할 수 있는 루틴 소요 시간 목록[m
+[31m-    private static final List<Integer> ALLOWED_DURATIONS = List.of(5, 10, 15, 20, 30);[m
+[32m+[m[32m    private static final List<Integer> ALLOWED_DURATIONS = List.of(10, 20, 30, 40, 50, 60);[m
+ [m
+     // 의존성 주입 필드[m
+ [m
+[36m@@ -271,7 +271,8 @@[m [mpublic class AiService {[m
+             - title은 30자 이하로 작성한다.[m
+             - description은 생성하지 않는다.[m
+             - recommendedTime은 사용자의 주요 활동 시간과 어울리게 작성한다.[m
+[31m-            - durationMinutes는 5, 10, 15, 20, 30 중 하나만 사용한다.[m
+[32m+[m[32m            - durationMinutes는 10, 20, 30, 40, 50, 60 중 하나만 사용한다.[m
+[32m+[m[32m            - durationMinutes는 루틴 수행 시간이며 최대 60분을 넘기지 않는다.[m
+             - 반복 여부는 만들지 않는다.[m
+             - 사용자가 바로 추가할 수 있는 구체적인 루틴 제목으로 만든다.[m
+             - 기존 루틴과 제목이 같거나 의미가 거의 같은 루틴은 추천하지 않는다.[m
+[36m@@ -767,14 +768,26 @@[m [mpublic class AiService {[m
+     private void insertRoutine(Long userId, Long categoryId, String title) {[m
+         jdbcTemplate.update("""[m
+             insert into routines[m
+[31m-            (user_id, category_id, title, alarm, state, cron_expression, start_time, end_time, created_at, updated_at)[m
+[31m-            values (?, ?, ?, ?, ?, ?, ?, ?, now(), now())[m
+[32m+[m[32m            ([m
+[32m+[m[32m                user_id,[m
+[32m+[m[32m                category_id,[m
+[32m+[m[32m                title,[m
+[32m+[m[32m                alarm,[m
+[32m+[m[32m                repeat_type,[m
+[32m+[m[32m                repeat_interval,[m
+[32m+[m[32m                repeat_unit,[m
+[32m+[m[32m                repeat_days,[m
+[32m+[m[32m                start_at,[m
+[32m+[m[32m                created_at,[m
+[32m+[m[32m                updated_at[m
+[32m+[m[32m            )[m
+[32m+[m[32m            values (?, ?, ?, ?, ?, ?, ?, ?, current_date, now(), now())[m
+             """,[m
+                 userId,[m
+                 categoryId,[m
+                 title,[m
+                 false,[m
+[31m-                true,[m
+[32m+[m[32m                "NONE",[m
+                 null,[m
+                 null,[m
+                 null[m


### PR DESCRIPTION
## 관련 이슈

- Closes #14 

---

## 작업 내용


- Gemini 연동을 OpenAI 기반 루틴 추천 기능으로 변경
- AI 루틴 추천 조건 선택지 조회 API 추가
- 사용자 정보(직업, 성별, 나이대)와 선택 조건(목적, 주요 활동 시간, 활동 타입, 취미)을 기반으로 루틴 5개 추천 기능 구현
- 사용자의 기존 루틴 목록을 조회하여 기존 루틴과 중복되지 않도록 추천 로직 보완
- AI 추천 결과를 AiLog에 저장하고 recommendationId 기반으로 선택 루틴 추가 가능하도록 구현
- 체크박스로 선택한 추천 루틴만 실제 routines 테이블에 추가하는 기능 구현
- 카테고리 선택 방식이 확정되지 않은 상태를 고려하여 추천 요청 또는 추가 요청 단계에서 categoryId를 받을 수 있도록 유동 처리
- 변경된 루틴 반복 설정 DB 구조에 맞춰 repeat_type 기본값을 NONE으로 저장하도록 수정
- 루틴 수행 시간 추천 기준을 10분 단위, 최대 60분으로 조정
- user 엔티티에 job 관련 소스 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

- 루틴 추천 후 등록되는 카테고리는 사용자가 옵션 선택할 때 함께 지정하도록 설정해 두었으나, 회의 내용에 따라 변경될 예정입니다.
-  `/recommend` 응답의 `recommendationId`는 프론트 상태값으로 저장해 두었다가, 사용자가 체크박스로 선택 후 추가할 때 `/api/v1/ai-routines/{recommendationId}/add`의 path variable로 전달하면 됩니다.
- 수행 시간까지 추천하도록 해 두었습니다. 이 역시 회의 내용에 따라 기능 추가할 예정입니다.
- 계정 당 일일 요청 수 제한 두는 것이 좋을 것 같으며 마찬가지로 회의 후 추가하겠습니다.