### PR TITLE
[Fix] 네이버 닉네임 처리 변경

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -47,10 +47,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                     if (userRepository.existsByEmail(email)) {
                         throw oauth2Error("An account with the same email already exists");
                     }
+
+                    if (isBlank(userInfo.getNickname())) {
+                        throw oauth2Error("OAuth2 nickname is required");
+                    }
                     return userRepository.save(
                             User.createOAuth(
                                     email,
-                                    defaultNickname(userInfo, email),
+                                    userInfo.getNickname(),
                                     userInfo.getProvider(),
                                     userInfo.getProviderId()
                             )
@@ -74,12 +78,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         };
     }
 
-    private String defaultNickname(OAuth2UserInfo userInfo, String email) {
-        if (!isBlank(userInfo.getNickname())) {
-            return userInfo.getNickname();
-        }
-        return email.split("@")[0];
-    }
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/NaverUserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/NaverUserInfo.java
@@ -30,7 +30,8 @@ public class NaverUserInfo implements OAuth2UserInfo {
 
     @Override
     public String getNickname() {
-        Object name = response == null ? null : response.get("name");
-        return name == null ? null : String.valueOf(name);
+        Object nickname = response == null ? null : response.get("nickname");
+        return nickname == null ? null : String.valueOf(nickname);
     }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,7 +42,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
-            scope: name, email
+            scope: nickname, email
             client-name: Naver
 
         provider:


### PR DESCRIPTION
## 관련 이슈

- Closes #36 

---

## 작업 내용

- Naver OAuth scope를 `nickname, email`로 변경
- Naver 사용자 정보에서 `nickname` 값을 읽도록 수정
- 닉네임이 없을 경우 이메일 앞부분으로 대체하지 않고 예외 처리하도록 수정

---

## 테스트 체크리스트

- [ ] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> Naver 소셜 로그인 시 닉네임을 필수값으로 처리하도록 수정했습니다.