### PR TITLE
[Fix] OAuth2 로그인 refresh token 저장 트랜잭션 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -3,6 +3,7 @@ package com.rutina.rutinabackend.domain.refreshToken.repository;
 import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -11,5 +12,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByTokenValue(String tokenValue);
 
+    @Transactional
     void deleteByUserIdAndDevice(Long userId, String device);
 }

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private String redirectUrl;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(
             HttpServletRequest request,
             HttpServletResponse response,


### PR DESCRIPTION
## 관련 이슈

- Closes #42

---

## 작업 내용
OAuth2 소셜 로그인 성공 후 refresh token을 갱신하는 과정에서 트랜잭션이 없어 JPA delete 쿼리 실행 시 500 오류가 발생하던 문제를 수정했습니다.
- `OAuth2SuccessHandler.onAuthenticationSuccess()`에 `@Transactional` 추가
- `RefreshTokenRepository.deleteByUserIdAndDevice()`에 `@Transactional` 명시
- OAuth2 로그인 성공 후 기존 refresh token 삭제와 신규 refresh token 저장이 트랜잭션 내에서 처리되도록 변경

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.