### PR TITLE
[Feat] 구글 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -74,6 +74,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         return switch (registrationId) {
             case "kakao" -> new KakaoUserInfo(attributes);
             case "naver" -> new NaverUserInfo(attributes);
+            case "google" -> new GoogleUserInfo(attributes);
             default -> throw oauth2Error("Unsupported provider: " + registrationId);
         };
     }

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/GoogleUserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/GoogleUserInfo.java
@@ -1,0 +1,35 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "GOOGLE";
+    }
+
+    @Override
+    public String getProviderId() {
+        Object id = attributes.get("sub");
+        return id == null ? null : String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = attributes.get("email");
+        return email == null ? null : String.valueOf(email);
+    }
+
+    @Override
+    public String getNickname() {
+        Object name = attributes.get("name");
+        return name == null ? null : String.valueOf(name);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,14 @@ spring:
             scope: nickname, email
             client-name: Naver
 
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            authorization-grant-type: authorization_code
+            scope: profile, email
+            client-name: Google
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 관련 이슈

- Closes #44

---

## 작업 내용

- Google OAuth2 client 설정 추가
- Google OAuth2 사용자 정보 매핑 추가
- 기존 OAuth2 로그인 흐름에 google provider 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인
- 로컬 Google 로그인 후 사용자 저장 확인
---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
- Google OAuth2는 공개 IP 주소를 Redirect URI로 등록할 수 없습니다.
  예: `http://서버주소/login/oauth2/code/google` 등록 불가 합니다.
  따라서 도메인/HTTPS 설정을 하고 구글 소셜로그인을 이용하거나 빼는게 좋을 것 같습니다.