### PR TITLE
[Feat] 닉네임 변경 기능 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.rutina.rutinabackend.domain.user.controller;
+
+import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
+import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
+import com.rutina.rutinabackend.domain.user.service.UserService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Tag(name = "User", description = "사용자 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "닉네임 변경")
+    @PatchMapping("/me/nickname")
+    public ApiResponse<NicknameUpdateResponse> updateNickname(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody NicknameUpdateRequest request
+    ) {
+        // JWT 필터에서 인증이 끝나면 UserDetails.username에 userId가 문자열로 들어가 있습니다.
+        // 그래서 서비스로 넘기기 전에 Long 타입으로 변환해서 사용합니다.
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        // 실제 닉네임 변경 로직은 서비스에서 처리하고, 컨트롤러는 요청/응답만 담당합니다.
+        NicknameUpdateResponse response = userService.updateNickname(userId, request);
+        return ApiResponse.ok("닉네임이 변경되었습니다.", response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// 닉네임 변경 요청에서 필요한 값만 받기 위한 DTO입니다.
+public record NicknameUpdateRequest(
+        // 공백 닉네임은 허용하지 않고, 길이를 30자로 제한합니다.
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 30, message = "닉네임은 30자 이하로 입력해주세요.")
+        String nickname
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+
+// 닉네임 변경 후 클라이언트에 내려줄 응답 DTO입니다.
+public record NicknameUpdateResponse(
+        Long userId,
+        String nickname
+) {
+    public static NicknameUpdateResponse from(User user) {
+        // 엔티티 전체를 그대로 노출하지 않고 필요한 값만 응답합니다.
+        return new NicknameUpdateResponse(user.getId(), user.getNickname());
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -75,4 +75,11 @@ public class User {
         return user;
     }
 
+    public void updateNickname(String nickname) {
+        // 엔티티 내부에서 닉네임을 변경하도록 메서드로 분리했습니다.
+        // 이렇게 하면 서비스에서 필드를 직접 수정하지 않아도 됩니다.
+        this.nickname = nickname;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
@@ -1,0 +1,32 @@
+package com.rutina.rutinabackend.domain.user.service;
+
+import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
+import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public NicknameUpdateResponse updateNickname(Long userId, NicknameUpdateRequest request) {
+        // 로그인한 사용자의 id로 User를 조회합니다.
+        // 존재하지 않는 사용자라면 공통 에러 코드로 예외를 발생시킵니다.
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+
+        // 닉네임 중복은 허용하기 때문에 별도의 중복 검사는 하지 않습니다.
+        // JPA 변경 감지로 트랜잭션이 끝날 때 update 쿼리가 실행됩니다.
+        user.updateNickname(request.nickname());
+
+        // 변경된 닉네임을 바로 응답으로 내려주기 위해 응답 DTO로 변환합니다.
+        return NicknameUpdateResponse.from(user);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -74,6 +74,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         return switch (registrationId) {
             case "kakao" -> new KakaoUserInfo(attributes);
             case "naver" -> new NaverUserInfo(attributes);
+            case "google" -> new GoogleUserInfo(attributes);
             default -> throw oauth2Error("Unsupported provider: " + registrationId);
         };
     }

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/GoogleUserInfo.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/GoogleUserInfo.java
@@ -1,0 +1,35 @@
+package com.rutina.rutinabackend.global.oauth2;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "GOOGLE";
+    }
+
+    @Override
+    public String getProviderId() {
+        Object id = attributes.get("sub");
+        return id == null ? null : String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        Object email = attributes.get("email");
+        return email == null ? null : String.valueOf(email);
+    }
+
+    @Override
+    public String getNickname() {
+        Object name = attributes.get("name");
+        return name == null ? null : String.valueOf(name);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,14 @@ spring:
             scope: nickname, email
             client-name: Naver
 
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            authorization-grant-type: authorization_code
+            scope: profile, email
+            client-name: Google
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize


### PR DESCRIPTION
## 관련 이슈

- Closes #46 

---

## 작업 내용

- 로그인한 사용자의 닉네임 변경 요청/응답 DTO를 추가했습니다.
- 사용자 엔티티에 닉네임 변경 메서드를 추가했습니다.
- 닉네임 변경 서비스 로직을 구현했습니다.
- `PATCH /api/v1/users/me/nickname` API 엔드포인트를 추가했습니다.

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.