### PR TITLE
[Feat] 로그인된 유저의 내 정보 조회

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.rutina.rutinabackend.domain.user.controller;
+
+import com.rutina.rutinabackend.domain.user.dto.UserResponse;
+import com.rutina.rutinabackend.domain.user.service.UserService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저 API")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 정보 조회")
+    @GetMapping("/me")
+    public ApiResponse<UserResponse> getMe(@AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        UserResponse response = userService.getMe(userId);
+        return ApiResponse.ok("내 정보를 불러왔습니다.", response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/UserResponse.java
@@ -1,0 +1,29 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+
+import java.time.OffsetDateTime;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String nickname,
+        String provider,
+        Integer gender,
+        String age,
+        String job,
+        OffsetDateTime createdAt
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getProvider(),
+                user.getGender(),
+                user.getAge(),
+                user.getJob(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
@@ -1,0 +1,23 @@
+package com.rutina.rutinabackend.domain.user.service;
+
+import com.rutina.rutinabackend.domain.user.dto.UserResponse;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponse getMe(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+        return UserResponse.from(user);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #50 

---

## 작업 내용

- 로그인된 유저가 자신의 프로필 정보를 조회할 수 있는 API를 구현
- JWT 인증이 필요하며 @AuthenticationPrincipal로 userId를 추출해 응답.
  
- feat: UserResponse DTO 추가 — id, email, nickname, provider, gender, age, job, createdAt 필드 및 UserResponse.from(User) 팩토리 포함
- feat: UserService 추가 - 내 정보 조회 — @Transactional(readOnly = true), 존재하지 않는 유저 시 USER_NOT_FOUND 예외 처리
- feat: UserController 추가 - GET /api/v1/users/me — Swagger @Tag/@Operation 적용, PUBLIC_URLS 미등록으로 JWT 인증 필수

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.