### PR TITLE
[Feat] 카테고리 숨김 기능, 스웨거 설명 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
@@ -43,16 +43,58 @@ public class CategoryController {
         return ApiResponse.created("카테고리가 생성되었습니다.", response);
     }
 
-    @Operation(summary = "내 카테고리 목록 조회")
+    @Operation(
+            summary = "내 카테고리 목록 조회",
+            description = """
+                로그인한 사용자의 카테고리 목록을 조회합니다.
+                숨김 처리되지 않은 카테고리(hidden=false)만 반환합니다.
+                앱의 기본 카테고리 목록 화면에서 사용합니다.
+                """
+    )
     @GetMapping
     public ApiResponse<List<CategoryResponse>> getCategories(
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // accessToken 인증 사용자 기준으로 본인 카테고리만 조회
         Long userId = Long.parseLong(userDetails.getUsername());
 
         List<CategoryResponse> response = categoryService.getCategories(userId);
         return ApiResponse.ok("카테고리 목록 조회에 성공했습니다.", response);
+    }
+
+    @Operation(
+            summary = "숨김 카테고리 목록 조회",
+            description = """
+                로그인한 사용자의 숨김 카테고리 목록을 조회합니다.
+                hidden=true 상태인 카테고리만 반환합니다.
+                숨김 카테고리를 다시 표시 상태로 변경할 때 사용할 수 있습니다.
+                """
+    )
+    @GetMapping("/hidden")
+    public ApiResponse<List<CategoryResponse>> getHiddenCategories(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<CategoryResponse> response = categoryService.getHiddenCategories(userId);
+        return ApiResponse.ok("숨김 카테고리 목록 조회에 성공했습니다.", response);
+    }
+
+    @Operation(
+            summary = "내 카테고리 전체 조회",
+            description = """
+                로그인한 사용자의 모든 카테고리를 조회합니다.
+                숨김 여부와 관계없이 hidden=true, hidden=false 카테고리를 모두 반환합니다.
+                관리자성 확인 또는 카테고리 관리 화면에서 사용할 수 있습니다.
+                """
+    )
+    @GetMapping("/all")
+    public ApiResponse<List<CategoryResponse>> getAllCategories(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<CategoryResponse> response = categoryService.getAllCategories(userId);
+        return ApiResponse.ok("전체 카테고리 목록 조회에 성공했습니다.", response);
     }
 
     @Operation(summary = "카테고리 단건 조회")

--- a/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/controller/CategoryController.java
@@ -25,7 +25,18 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @Operation(summary = "카테고리 생성")
+    @Operation(
+            summary = "카테고리 생성",
+            description = """
+                로그인한 사용자의 새 카테고리를 생성합니다.
+
+                요청 시 카테고리 이름(name)과 색상 코드(colorCode)를 전달합니다.
+                새로 생성된 카테고리는 기본적으로 숨김 상태가 아니며(hidden=false),
+                sortOrder는 0으로 저장되어 목록의 가장 위에 표시됩니다.
+
+                기존 카테고리들은 sortOrder가 1씩 증가하여 뒤로 밀립니다.
+                """
+    )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<CategoryResponse> createCategory(
@@ -97,7 +108,16 @@ public class CategoryController {
         return ApiResponse.ok("전체 카테고리 목록 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "카테고리 단건 조회")
+    @Operation(
+            summary = "카테고리 단건 조회",
+            description = """
+                특정 카테고리 1개의 상세 정보를 조회합니다.
+
+                path variable로 전달한 categoryId가 로그인한 사용자의 카테고리인 경우에만 조회됩니다.
+                다른 사용자의 카테고리이거나 존재하지 않는 카테고리인 경우 조회되지 않습니다.
+
+                """
+    )
     @GetMapping("/{categoryId}")
     public ApiResponse<CategoryResponse> getCategory(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -111,7 +131,19 @@ public class CategoryController {
         return ApiResponse.ok("카테고리 조회에 성공했습니다.", response);
     }
 
-    @Operation(summary = "카테고리 수정")
+    @Operation(
+            summary = "카테고리 수정",
+            description = """
+                카테고리 이름, 색상 코드, 숨김 여부를 수정합니다.
+
+                hidden=true로 수정하면 기본 카테고리 목록 조회(GET /api/v1/categories)에서 제외됩니다.
+                hidden=false로 수정하면 다시 기본 카테고리 목록에 표시됩니다.
+
+                카테고리 순서는 이 API에서 수정하지 않습니다.
+                순서 변경은 별도의 카테고리 순서 변경 API를 사용해야 합니다.
+                
+                """
+    )
     @PutMapping("/{categoryId}")
     public ApiResponse<CategoryResponse> updateCategory(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -126,7 +158,29 @@ public class CategoryController {
         return ApiResponse.ok("카테고리가 수정되었습니다.", response);
     }
 
-    @Operation(summary = "카테고리 순서 변경")
+    @Operation(
+            summary = "카테고리 순서 변경",
+            description = """
+                카테고리 목록의 표시 순서를 변경합니다.
+
+                프론트에서 드래그 앤 드롭으로 카테고리 순서를 변경한 뒤,
+                최종 순서대로 categoryIds 배열을 전달합니다.
+
+                배열의 첫 번째 id는 sortOrder=0,
+                두 번째 id는 sortOrder=1,
+                세 번째 id는 sortOrder=2로 저장됩니다.
+
+                주의:
+                - categoryIds에는 로그인한 사용자의 카테고리 id만 포함되어야 합니다.
+                - 현재 화면에 표시 중인 카테고리 순서 그대로 전달해야 합니다.
+                - 숨김 카테고리를 기본 목록에서 제외하는 정책이라면, 프론트는 hidden=false 카테고리 id만 전달해야 합니다.
+
+                요청 예시:
+                {
+                  "categoryIds": [3, 1, 2]
+                }
+                """
+    )
     @PutMapping("/reorder")
     public ApiResponse<Void> reorderCategories(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -140,7 +194,22 @@ public class CategoryController {
         return ApiResponse.ok("카테고리 순서가 변경되었습니다.", null);
     }
 
-    @Operation(summary = "카테고리 삭제")
+    @Operation(
+            summary = "카테고리 삭제",
+            description = """
+                특정 카테고리를 삭제합니다.
+
+                삭제 시 해당 카테고리에 속한 루틴도 함께 삭제됩니다.
+                단순히 화면에서 보이지 않게 하려는 목적이라면 삭제 API가 아니라
+                카테고리 수정 API에서 hidden=true로 변경해야 합니다.
+
+                주의:
+                - 삭제는 복구가 어렵습니다.
+                - 프론트에서는 삭제 전 확인 모달을 표시하는 것을 권장합니다.
+                - 카테고리만 숨기고 싶다면 PUT /api/v1/categories/{categoryId} 요청에서 hidden=true를 사용합니다.
+                
+                """
+    )
     @DeleteMapping("/{categoryId}")
     public ApiResponse<Void> deleteCategory(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
@@ -24,6 +24,8 @@ public class CategoryResponse {
     // 목록 조회 시 프론트가 현재 순서를 알 수 있도록 응답에 포함
     private Integer sortOrder;
 
+    private Boolean hidden;
+
     // Entity -> Response DTO 변환
     public static CategoryResponse from(Category category) {
         return CategoryResponse.builder()

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryResponse.java
@@ -32,6 +32,7 @@ public class CategoryResponse {
                 .colorCode(category.getColorCode())
                 .rtSum(category.getRtSum())
                 .sortOrder(category.getSortOrder())
+                .hidden(category.getHidden())
                 .build();
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/dto/CategoryUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.rutina.rutinabackend.domain.category.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -21,5 +22,10 @@ public class CategoryUpdateRequest {
             regexp = "^#[0-9A-Fa-f]{6}$",
             message = "색상 코드는 #RRGGBB 형식이어야 합니다."
     )
+
     private String colorCode;
+
+    //숨김 여부 - False or True 필수
+    @NotNull(message = "숨김 여부는 필수입니다.")
+    private Boolean hidden;
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/entity/Category.java
@@ -31,6 +31,9 @@ public class Category {
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder;  // 정렬 순서
 
+    @Column(nullable = false)
+    private Boolean hidden = false; // 카테고리 숨김(True = 숨김 상태)
+
     @Column(name = "created_at", nullable = false, updatable = false,
             columnDefinition = "TIMESTAMPTZ DEFAULT now()")
     private OffsetDateTime createdAt;
@@ -52,9 +55,10 @@ public class Category {
         return category;
     }
     // ── 카테고리 수정 시 사용 ──────────────────────────
-    public void update(String name, String colorCode) {
+    public void update(String name, String colorCode, Boolean hidden) {
         this.name = name;
         this.colorCode = colorCode;
+        this.hidden = hidden;
         this.updatedAt = OffsetDateTime.now();
     }
 
@@ -64,4 +68,7 @@ public class Category {
         this.updatedAt = OffsetDateTime.now();
     }
 
+    public void updateHidden(Boolean hidden) {
+        this.hidden = hidden;
+    }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
@@ -9,8 +9,15 @@ import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    // 내 카테고리 목록 조회
+
+    // 내 카테고리 목록 조회 - 전체
     List<Category> findAllByUser_IdOrderBySortOrderAscIdAsc(Long userId);
+
+    // 내 카테고리 목록 조회 - 숨김 제외
+    List<Category> findAllByUser_IdAndHiddenFalseOrderBySortOrderAscIdAsc(Long userId);
+
+    // 내 숨김 카테고리 목록 조회
+    List<Category> findAllByUser_IdAndHiddenTrueOrderBySortOrderAscIdAsc(Long userId);
 
     // 내 카테고리 단건 조회
     Optional<Category> findByIdAndUser_Id(Long categoryId, Long userId);

--- a/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
@@ -65,8 +65,24 @@ public class CategoryService {
         return CategoryResponse.from(savedCategory);
     }
 
-    // 내 카테고리 전체 조회
+    // 내 카테고리 목록 조회 - 숨김 제외
     public List<CategoryResponse> getCategories(Long userId) {
+        return categoryRepository.findAllByUser_IdAndHiddenFalseOrderBySortOrderAscIdAsc(userId)
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
+    // 내 숨김 카테고리 목록 조회
+    public List<CategoryResponse> getHiddenCategories(Long userId) {
+        return categoryRepository.findAllByUser_IdAndHiddenTrueOrderBySortOrderAscIdAsc(userId)
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
+    // 내 카테고리 전체 조회
+    public List<CategoryResponse> getAllCategories(Long userId) {
         return categoryRepository.findAllByUser_IdOrderBySortOrderAscIdAsc(userId)
                 .stream()
                 .map(CategoryResponse::from)
@@ -92,7 +108,8 @@ public class CategoryService {
 
         category.update(
                 categoryName,
-                request.getColorCode()
+                request.getColorCode(),
+                request.getHidden()
         );
 
         return CategoryResponse.from(category);

--- a/src/main/resources/db/migration/V8__add_hidden_to_categories.sql
+++ b/src/main/resources/db/migration/V8__add_hidden_to_categories.sql
@@ -1,0 +1,4 @@
+-- 카테고리 테이블에 hidden 필드 추가 --
+
+ALTER TABLE categories
+    ADD COLUMN hidden boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## 관련 이슈

- Closes #54 

---

## 작업 내용

- 카테고리 숨김 처리를 위한 `hidden` 필드 반영
- 카테고리 수정 API에서 이름, 색상 코드와 함께 숨김 여부를 수정할 수 있도록 변경
- 기본 카테고리 목록 조회 시 숨김 처리된 카테고리는 제외되도록 수정
- 숨김 카테고리 목록 조회 API 추가
- 숨김 여부와 관계없이 전체 카테고리를 조회할 수 있는 API 추가
- 카테고리 응답 DTO에 `hidden` 값 포함
- 프론트엔드 이해를 돕기 위해 Swagger API 설명 보강
  - 생성, 조회, 수정, 순서 변경, 삭제 API 설명 추가
  - 숨김 처리와 삭제 처리의 차이 설명 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.