### PR TITLE
[Feat] 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.rutina.rutinabackend.domain.user.controller;
 
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
+import com.rutina.rutinabackend.domain.user.dto.PasswordChangeRequest;
 import com.rutina.rutinabackend.domain.user.service.UserService;
 import com.rutina.rutinabackend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,5 +37,16 @@ public class UserController {
         // 실제 닉네임 변경 로직은 서비스에서 처리하고, 컨트롤러는 요청/응답만 담당합니다.
         NicknameUpdateResponse response = userService.updateNickname(userId, request);
         return ApiResponse.ok("닉네임이 변경되었습니다.", response);
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @PatchMapping("/me/password")
+    public ApiResponse<Void> changePassword(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody PasswordChangeRequest request
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        userService.changePassword(userId, request);
+        return ApiResponse.ok("비밀번호가 변경되었습니다.", null);
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/PasswordChangeRequest.java
@@ -1,0 +1,14 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordChangeRequest(
+
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호를 입력해주세요.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        String newPassword
+) {}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -85,4 +85,9 @@ public class User {
         this.updatedAt = OffsetDateTime.now();
     }
 
+    public void changePassword(String encodedNewPassword) {
+        this.password = encodedNewPassword;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
@@ -2,10 +2,12 @@ package com.rutina.rutinabackend.domain.user.service;
 
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
+import com.rutina.rutinabackend.domain.user.dto.PasswordChangeRequest;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public NicknameUpdateResponse updateNickname(Long userId, NicknameUpdateRequest request) {
@@ -28,5 +31,28 @@ public class UserService {
 
         // 변경된 닉네임을 바로 응답으로 내려주기 위해 응답 DTO로 변환합니다.
         return NicknameUpdateResponse.from(user);
+    }
+
+    @Transactional
+    public void changePassword(Long userId, PasswordChangeRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+
+        // 로컬 로그인 유저인지 확인
+        if (!"LOCAL".equals(user.getProvider())) {
+            throw ErrorCode.NOT_LOCAL_USER.toException();
+        }
+
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw ErrorCode.WRONG_PASSWORD.toException();
+        }
+
+        // 새로운 비밀번호 검증
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {
+            throw ErrorCode.SAME_AS_CURRENT_PASSWORD.toException();
+        }
+
+        user.changePassword(passwordEncoder.encode(request.newPassword()));
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -13,6 +13,9 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_002", "이메일 또는 비밀번호가 올바르지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_003", "존재하지 않는 사용자입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "유효하지 않거나 만료된 리프레시 토큰입니다."),
+    NOT_LOCAL_USER(HttpStatus.FORBIDDEN, "AUTH_005", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_006", "현재 비밀번호가 올바르지 않습니다."),
+    SAME_AS_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH_007", "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
 
     // 공통
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값이 올바르지 않습니다.");


### PR DESCRIPTION
## 관련 이슈

- Closes #52 

---

## 작업 내용

LOCAL 회원가입 유저만 비밀번호를 변경할 수 있는 API를 구현했습니다.
  소셜 로그인 유저, 현재 비밀번호 불일치, 동일 비밀번호 재사용 등 3가지 케이스를 명시적 에러로 처리합니다.
  기존 UserController / UserService에 엔드포인트와 메서드를 추가하는 방식으로 구현했습니다.

  - feat: 비밀번호 변경 관련 ErrorCode 추가 — NOT_LOCAL_USER(403), WRONG_PASSWORD(401), SAME_AS_CURRENT_PASSWORD(400)
  - feat: User 엔티티에 changePassword 메서드 추가 — password, updatedAt 갱신
  - feat: PasswordChangeRequest DTO 추가 — currentPassword, newPassword 필드 및 @NotBlank / @Size 검증
  - feat: 비밀번호 변경 API 구현 — UserService에 검증 로직(provider 확인 → 현재 비밀번호 검증 → 동일 비밀번호 검증 → BCrypt 인코딩 후 변경), UserController에 PATCH ``/api/v1/users/me/password`` 엔드포인트 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.