### PR TITLE
[Feat] DailyTarget 완료 토글 API 추가 및 루틴 목록 조회에 완료 여부 반영

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/controller/DailyTargetController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/controller/DailyTargetController.java
@@ -1,0 +1,36 @@
+package com.rutina.rutinabackend.domain.dailytarget.controller;
+
+import com.rutina.rutinabackend.domain.dailytarget.dto.DailyTargetResponse;
+import com.rutina.rutinabackend.domain.dailytarget.service.DailyTargetService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/routines")
+@Tag(name = "DailyTarget", description = "루틴 완료 API")
+public class DailyTargetController {
+
+    private final DailyTargetService dailyTargetService;
+
+    @Operation(summary = "루틴 완료/비완료 토글")
+    @PostMapping("/{routineId}/daily-targets/toggle")
+    public ApiResponse<DailyTargetResponse> toggle(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long routineId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        DailyTargetResponse response = dailyTargetService.toggle(userId, routineId, date);
+        return ApiResponse.ok("루틴 완료 상태가 변경되었습니다.", response);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/dto/DailyTargetResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/dto/DailyTargetResponse.java
@@ -1,0 +1,25 @@
+package com.rutina.rutinabackend.domain.dailytarget.dto;
+
+import com.rutina.rutinabackend.domain.dailytarget.entity.DailyTarget;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DailyTargetResponse {
+
+    private Long routineId;
+    private LocalDate targetDate;
+    private Boolean isCompleted;
+
+    // 엔티티 → 응답 DTO 변환 정적 팩토리
+    public static DailyTargetResponse from(DailyTarget dailyTarget) {
+        return DailyTargetResponse.builder()
+                .routineId(dailyTarget.getRoutine().getId())
+                .targetDate(dailyTarget.getTargetDate())
+                .isCompleted(dailyTarget.getIsCompleted())
+                .build();
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/entity/DailyTarget.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/entity/DailyTarget.java
@@ -45,4 +45,10 @@ public class DailyTarget {
         dailyTarget.updatedAt = OffsetDateTime.now();
         return dailyTarget;
     }
+
+    // ── 완료 상태 토글 ─────────────────────────────────────
+    public void toggleCompleted() {
+        this.isCompleted = !this.isCompleted;
+        this.updatedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
@@ -6,9 +6,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DailyTargetRepository extends JpaRepository<DailyTarget, Long> {
     List<DailyTarget> findByRoutineId(Long routineId);
-    List<DailyTarget> findByRoutineIdAndTargetDate(Long routineId, LocalDate targetDate);
+    Optional<DailyTarget> findByRoutineIdAndTargetDate(Long routineId, LocalDate targetDate);
+    List<DailyTarget> findByRoutineIdInAndTargetDate(List<Long> routineIds, LocalDate targetDate);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/service/DailyTargetService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/service/DailyTargetService.java
@@ -1,0 +1,44 @@
+package com.rutina.rutinabackend.domain.dailytarget.service;
+
+import com.rutina.rutinabackend.domain.dailytarget.dto.DailyTargetResponse;
+import com.rutina.rutinabackend.domain.dailytarget.entity.DailyTarget;
+import com.rutina.rutinabackend.domain.dailytarget.repository.DailyTargetRepository;
+import com.rutina.rutinabackend.domain.routine.entity.Routine;
+import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class DailyTargetService {
+
+    private final DailyTargetRepository dailyTargetRepository;
+    private final RoutineRepository routineRepository;
+
+    // ── 루틴 완료/비완료 토글 ──────────────────────────────────────
+    // 해당 날짜의 DailyTarget이 없으면 새로 생성(isCompleted=true),
+    // 있으면 현재 상태를 반전
+    @Transactional
+    public DailyTargetResponse toggle(Long userId, Long routineId, LocalDate targetDate) {
+        Routine routine = routineRepository.findByIdAndUserId(routineId, userId)
+                .orElseThrow(ErrorCode.ROUTINE_NOT_FOUND::toException);
+
+        DailyTarget dailyTarget = dailyTargetRepository
+                .findByRoutineIdAndTargetDate(routineId, targetDate)
+                .map(dt -> {
+                    dt.toggleCompleted();
+                    return dt;
+                })
+                .orElseGet(() -> {
+                    DailyTarget created = DailyTarget.create(routine, targetDate);
+                    created.toggleCompleted(); // false → true
+                    return dailyTargetRepository.save(created);
+                });
+
+        return DailyTargetResponse.from(dailyTarget);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
@@ -28,10 +28,9 @@ public class RoutineResponse {
     private LocalTime endTime;
     private LocalDate startAt;
     private LocalDate endAt;
+    private Boolean isCompleted;        // date 없는 조회 시 null, date 있는 조회 시 true/false
 
-    // 엔티티 → 응답 DTO 변환 정적 팩토리
-    // repeatDays: routine.getRepeatDays()가 null이면 빈 리스트,
-    //             아니면 쉼표로 split 후 DayOfWeek::valueOf로 매핑
+    // 엔티티 → 응답 DTO 변환 정적 팩토리 (date 없는 조회용 - isCompleted = null)
     public static RoutineResponse from(Routine routine) {
         List<DayOfWeek> repeatDays = routine.getRepeatDays() == null
                 ? Collections.emptyList()
@@ -53,6 +52,32 @@ public class RoutineResponse {
                 .endTime(routine.getEndTime())
                 .startAt(routine.getStartAt())
                 .endAt(routine.getEndAt())
+                .build();
+    }
+
+    // 엔티티 → 응답 DTO 변환 정적 팩토리 (date 있는 조회용 - isCompleted 값 포함)
+    public static RoutineResponse from(Routine routine, boolean isCompleted) {
+        List<DayOfWeek> repeatDays = routine.getRepeatDays() == null
+                ? Collections.emptyList()
+                : Arrays.stream(routine.getRepeatDays().split(","))
+                        .map(DayOfWeek::valueOf)
+                        .collect(Collectors.toList());
+
+        return RoutineResponse.builder()
+                .id(routine.getId())
+                .categoryId(routine.getCategory().getId())
+                .categoryColorCode(routine.getCategory() != null ? routine.getCategory().getColorCode() : null)
+                .title(routine.getTitle())
+                .alarm(routine.getAlarm())
+                .repeatType(routine.getRepeatType())
+                .repeatInterval(routine.getRepeatInterval())
+                .repeatUnit(routine.getRepeatUnit())
+                .repeatDays(repeatDays)
+                .startTime(routine.getStartTime())
+                .endTime(routine.getEndTime())
+                .startAt(routine.getStartAt())
+                .endAt(routine.getEndAt())
+                .isCompleted(isCompleted)
                 .build();
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
@@ -2,6 +2,8 @@ package com.rutina.rutinabackend.domain.routine.service;
 
 import com.rutina.rutinabackend.domain.category.entity.Category;
 import com.rutina.rutinabackend.domain.category.repository.CategoryRepository;
+import com.rutina.rutinabackend.domain.dailytarget.entity.DailyTarget;
+import com.rutina.rutinabackend.domain.dailytarget.repository.DailyTargetRepository;
 import com.rutina.rutinabackend.domain.routine.dto.*;
 import com.rutina.rutinabackend.domain.routine.entity.Routine;
 import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
@@ -20,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,6 +34,7 @@ public class RoutineService {
     private final RoutineRepository routineRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final DailyTargetRepository dailyTargetRepository;
 
     // ── 루틴 생성 ─────────────────────────────────────────────────
     @Transactional
@@ -87,6 +91,7 @@ public class RoutineService {
     // date가 있으면 2단계 필터링:
     //   1단계: DB 쿼리로 유효 기간(start_at <= date <= end_at) 내 루틴 추출
     //   2단계: isActiveOnDate()로 repeat_type별 날짜 계산 필터링
+    // date가 있으면 DailyTarget 일괄 조회 후 isCompleted 포함 응답 (N+1 방지)
     public List<RoutineResponse> getRoutines(Long userId, Long categoryId, LocalDate date) {
         List<Routine> routines;
 
@@ -106,8 +111,20 @@ public class RoutineService {
                     .collect(Collectors.toList());
         }
 
+        if (date == null) {
+            return routines.stream()
+                    .map(RoutineResponse::from)
+                    .collect(Collectors.toList());
+        }
+
+        List<Long> routineIds = routines.stream().map(Routine::getId).collect(Collectors.toList());
+        Map<Long, Boolean> completedMap = dailyTargetRepository
+                .findByRoutineIdInAndTargetDate(routineIds, date)
+                .stream()
+                .collect(Collectors.toMap(dt -> dt.getRoutine().getId(), DailyTarget::getIsCompleted));
+
         return routines.stream()
-                .map(RoutineResponse::from)
+                .map(r -> RoutineResponse.from(r, completedMap.getOrDefault(r.getId(), false)))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_003", "존재하지 않는 사용자입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "유효하지 않거나 만료된 리프레시 토큰입니다."),
 
+    // 루틴
+    ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE_001", "루틴을 찾을 수 없습니다."),
+
     // 공통
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "입력값이 올바르지 않습니다.");
 


### PR DESCRIPTION
## 관련 이슈

- Closes #53 

---

## 작업 내용  

  루틴의 일별 완료 여부를 관리하는 DailyTarget 도메인에 완료/비완료 토글 API를 추가했습니다.
  루틴 목록 조회 시 date 파라미터가 있으면 각 루틴의 완료 여부(isCompleted)를 함께 반환하도록 개선했으며, N+1 문제를 방지하기 위해 DailyTarget을 일괄 조회 후 매핑합니다.
  해당 날짜에 DailyTarget이 없으면 자동 생성(isCompleted=true)하고, 있으면 현재 상태를 반전합니다.

  - feat: ROUTINE_NOT_FOUND 에러 코드 추가
  - feat: DailyTarget 엔티티에 생성 팩토리(create) 및 완료 토글 메서드(toggleCompleted) 추가
  - feat: DailyTarget 조회 쿼리 메서드 추가 (findByRoutineIdAndTargetDate, findByRoutineIdInAndTargetDate)
  - feat: 루틴 완료/비완료 토글 API 추가 (POST ``/api/v1/routines/{routineId}/daily-targets/toggle``)
  - feat: 루틴 목록 조회에 일별 완료 여부(isCompleted) 반영

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

---

## 참고사항

> 프론트가 활성화된 날에만 완료 버튼을 노출하니까 서버에서 따로 검증을 하지는 않도록 했습니다.