### PR TITLE
[Chore] GitHub Actions CI/CD 파이프라인 개선       

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   # =========================================
-  # Job 1: 빌드 + Docker 이미지 생성 및 ghcr.io push
+  # Job 1: Docker 이미지 생성 및 ghcr.io push
+  # bootJar는 Dockerfile 멀티 스테이지 빌드에서 실행됨
+  # CI에서 이미 검증된 코드가 머지된 이후 실행되므로 중복 빌드 불필요
   # =========================================
   build:
     runs-on: ubuntu-latest  # GitHub이 제공하는 Ubuntu 환경에서 실행
@@ -23,24 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # JDK 21 설치 (Gradle 빌드에 필요)
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      # gradlew 실행 권한 부여 (Linux 환경에서 필요)
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      # Gradle로 JAR 파일 빌드
-      # Dockerfile 안에서도 빌드하지만, 여기서 먼저 실행해서 빌드 에러를 빠르게 확인
-      - name: Build with Gradle
-        run: ./gradlew bootJar --no-daemon
-
-      # ghcr.io(GitHub Container Registry) 로그인
-      # GITHUB_TOKEN은 GitHub이 자동으로 제공
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -48,10 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Docker 이미지 빌드 후 ghcr.io에 push
-      # 태그를 브랜치명으로 지정:
-      #   main   push → ghcr.io/induk-capstone-team/rutina-backend:main
-      #   develop push → ghcr.io/induk-capstone-team/rutina-backend:develop
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -60,14 +40,27 @@ jobs:
           tags: ghcr.io/induk-capstone-team/rutina-backend:${{ github.ref_name }}
 
   # =========================================
-  # Job 2: 서버에 배포
-  # build job이 성공해야 실행됨 (needs: build)
+  # Job 2: 서버에 .env 생성 후 배포
   # =========================================
   deploy:
     needs: build  # build job 완료 후 실행
     runs-on: ubuntu-latest
 
     steps:
+      # ENV_FILE Secret 내용을 Actions runner에 .env로 기록 후 서버로 전송
+      # 환경변수 추가/수정/삭제는 GitHub Secrets의 ENV_FILE만 편집하면 됨 (cd.yml 수정 불필요)
+      - name: Write .env from secret
+        run: echo "${{ secrets.ENV_FILE }}" > .env
+
+      - name: Copy .env to Lightsail
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ubuntu
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          source: ".env"
+          target: "/home/ubuntu/rutina/"
+
       # Lightsail 서버에 SSH 접속하여 배포 스크립트 실행
       - name: Deploy to Lightsail
         uses: appleboy/ssh-action@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 
 on:
-  workflow_dispatch:  # 수동으로만 실행
+  pull_request: # PR 요청시 실행
+    branches:
+      - main
+      - develop
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch:
     inputs:
       branch:
         description: '빌드 테스트할 브랜치'
@@ -13,12 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write   # ghcr.io 이미지 빌드 권한
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.head_ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -29,5 +36,23 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # 컴파일 에러 빠르게 확인
       - name: Build with Gradle
         run: ./gradlew bootJar --no-daemon
+
+      # ghcr.io 로그인 (이미지 빌드 캐시 활용 목적, push는 안 함)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 서버와 동일한 방식으로 Docker 이미지 빌드 검증 (push 없이 로컬 빌드만)
+      # CD에서 push하는 태그(브랜치명)와 동일한 Dockerfile 사용
+      - name: Build Docker image (verify only, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/induk-capstone-team/rutina-backend:ci-test


### PR DESCRIPTION
## 관련 이슈

- Closes #58 

---

## 작업 내용
 
- CI 트리거 추가: `feat/*` → `develop`, `main` PR 오픈/업데이트 시 자동 실행
- CI에 Docker 이미지 빌드 검증 단계 추가 (`push: false`, ghcr.io 업로드 없이 빌드만)
- CD deploy job에 `ENV_FILE` Secret → `.env` 자동 생성 및 서버 전송 추가 (팀원 서버 직접 접근 불필요)
- CD build job에서 중복 `bootJar` 빌드 단계 제거 (Dockerfile 멀티 스테이지에서 처리)
- `docker-compose.yml`에서 deprecated `version: '3.8'` 필드 제거

---
 
## 참고사항
 
> - 이제 CI가 실패하면 머지가 안 됩니다.
> - GitHub Secrets(레포 Settings → Secrets and variables → Actions) `ENV_FILE` 에서 환경 변수를 관리하면 됩니다.
> - `LIGHTSAIL_HOST`, `LIGHTSAIL_SSH_KEY`: 기존 값 유지(수정하지 말아주세요)
>
> **`ENV_FILE` Secret 관리 방법**
> - 환경변수 추가/수정/삭제 시 `ENV_FILE` Secret만 편집 (cd.yml 수정 불필요)
> - CD 실행 시 Secret 내용이 서버 `/home/ubuntu/rutina/.env`로 자동 생성됨