### PR TITLE
[Feat] daily_targets에 routine_id FK ON DELETE CASCADE 추가

### DIFF
--- a/src/main/resources/db/migration/V9__add_cascade_delete_daily_targets.sql
+++ b/src/main/resources/db/migration/V9__add_cascade_delete_daily_targets.sql
@@ -1,0 +1,9 @@
+-- 외래키에 ON DELETE CASCADE 추가 --
+ALTER TABLE daily_targets
+DROP CONSTRAINT IF EXISTS daily_targets_routine_id_fkey;
+
+ALTER TABLE daily_targets
+    ADD CONSTRAINT daily_targets_routine_id_fkey
+        FOREIGN KEY (routine_id)
+            REFERENCES routines(id)
+            ON DELETE CASCADE;


### PR DESCRIPTION
## 관련 이슈

- Closes #60 

---

## 작업 내용  

- daily_targets 테이블의 routine_id 외래키에 ON DELETE CASCADE 옵션을 추가.
- 루틴(routines) 삭제 시 연결된 daily_targets 레코드가 자동으로 함께 삭제.


---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.