### PR TITLE
[Feat] AI 사용 횟수 제한과 전반적인 기능 개선

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/constant/AiRoutineOptionConstants.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/constant/AiRoutineOptionConstants.java
@@ -1,0 +1,52 @@
+package com.rutina.rutinabackend.domain.ailog.constant;
+
+import java.util.List;
+
+public final class AiRoutineOptionConstants {
+
+    private AiRoutineOptionConstants() {
+    }
+
+    public static final List<String> PURPOSES = List.of(
+            "건강 관리",
+            "자기계발",
+            "공부/집중",
+            "생활 습관 개선",
+            "취미 관리"
+    );
+
+    public static final List<String> MAIN_ACTIVITY_TIMES = List.of(
+            "아침",
+            "오전",
+            "오후",
+            "저녁",
+            "밤"
+    );
+
+    public static final List<String> ACTIVITY_TYPES = List.of(
+            "실내 활동",
+            "야외 활동",
+            "정적인 활동",
+            "동적인 활동",
+            "혼자 하는 활동",
+            "함께 하는 활동"
+    );
+
+    public static final List<String> HOBBIES = List.of(
+            "독서",
+            "운동",
+            "음악",
+            "영화/드라마",
+            "게임",
+            "요리",
+            "산책",
+            "일기",
+            "공부",
+            "청소/정리",
+            "없음"
+    );
+
+    public static final List<Integer> ALLOWED_DURATIONS = List.of(
+            10, 20, 30, 40, 50, 60
+    );
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -5,28 +5,46 @@ import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineAddResponse;
 import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineOptionValuesResponse;
 import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineRecommendRequest;
 import com.rutina.rutinabackend.domain.ailog.dto.AiRoutineRecommendResponse;
-//import com.rutina.rutinabackend.domain.ailog.dto.AiRequest;
-//import com.rutina.rutinabackend.domain.ailog.dto.AiResponse;
 import com.rutina.rutinabackend.domain.ailog.service.AiService;
 import com.rutina.rutinabackend.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/v1/ai-routines")
 @RequiredArgsConstructor
-    @Tag(name = "AI Routine", description = "AI 루틴 추천 API")
-    public class AiController {
+@Tag(name = "AI Routine", description = "AI 루틴 추천 API")
+public class AiController {
 
-    // 루틴 추천 조건 선택지 조회 API
     private final AiService aiService;
 
-    @Operation(summary = "AI 루틴 추천 조건 선택지 조회")
+    @Operation(
+            summary = "AI 루틴 추천 조건 선택지 조회",
+            description = """
+                    AI 루틴 추천 요청에 사용할 선택지 목록을 조회합니다.
+                    
+                    프론트에서는 이 API로 목적, 주요 활동 시간, 활동 타입, 취미 선택지를 받아
+                    사용자가 직접 입력하지 않고 정해진 선택지 중에서 고를 수 있도록 처리합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "AI 루틴 추천 조건 선택지 조회 성공"
+            )
+    })
     @GetMapping("/options")
     public ApiResponse<AiRoutineOptionValuesResponse> getOptions() {
         return ApiResponse.ok(
@@ -35,8 +53,57 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         );
     }
 
-    // AI 루틴 추천 생성 API
-    @Operation(summary = "AI 루틴 추천 생성")
+    @Operation(
+            summary = "AI 루틴 추천 생성",
+            description = """
+                    로그인한 사용자의 직업, 성별, 나이대와 사용자가 선택한 조건을 기반으로
+                    AI가 루틴 후보 5개를 추천합니다.
+                    
+                    일반 사용자는 계정당 하루 3회까지만 AI 추천을 요청할 수 있습니다.
+                    기준 시간은 한국 시간 기준 매일 00:00에 초기화됩니다.
+                    
+                    ADMIN 계정은 하루 요청 횟수 제한에서 제외됩니다.
+                    
+                    추천 결과는 바로 루틴으로 저장되지 않고, recommendationId와 함께 후보 목록으로 반환됩니다.
+                    이후 사용자가 원하는 후보를 선택하여 추가 API를 호출해야 실제 루틴으로 저장됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "AI 루틴 추천 생성 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청값 오류 또는 사용자 프로필 정보 부족"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "429",
+                    description = "AI 일일 요청 횟수 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "AI_DAILY_LIMIT_EXCEEDED",
+                                    value = """
+                                            {
+                                              "success": false,
+                                              "code": "AI_DAILY_LIMIT_EXCEEDED",
+                                              "message": "AI 추천은 하루에 3번까지만 요청할 수 있습니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "AI 응답 변환 실패 또는 추천 결과 오류"
+            )
+    })
     @PostMapping("/recommend")
     public ApiResponse<AiRoutineRecommendResponse> recommend(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -48,12 +115,49 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         );
     }
 
-    // AI 추천 루틴 중 사용자가 선택한 루틴만 추가하는 API
-    @Operation(summary = "선택한 AI 추천 루틴 추가")
+    @Operation(
+            summary = "선택한 AI 추천 루틴 추가",
+            description = """
+                    AI 추천 결과 중 사용자가 선택한 루틴만 실제 routines 테이블에 추가합니다.
+                    
+                    recommendationId는 AI 루틴 추천 생성 API에서 반환된 값입니다.
+                    selectedOptionIds에는 사용자가 체크한 optionId 목록을 전달합니다.
+                    
+                    categoryId는 요청 body에서 전달한 값을 우선 사용합니다.
+                    요청 body에 categoryId가 없으면 추천 요청 당시 저장된 categoryId를 사용합니다.
+                    둘 다 없으면 루틴을 추가할 수 없습니다.
+                    
+                    이미 같은 제목의 루틴이 존재하는 경우 중복 추가하지 않습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "선택한 AI 추천 루틴 추가 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 선택값, 카테고리 오류 또는 추가할 루틴 미선택"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "AI 추천 기록을 찾을 수 없음"
+            )
+    })
     @PostMapping("/{recommendationId}/add")
     public ApiResponse<AiRoutineAddResponse> addRecommendedRoutines(
             @AuthenticationPrincipal UserDetails userDetails,
+
+            @Parameter(
+                    description = "AI 루틴 추천 생성 API에서 반환된 추천 기록 ID",
+                    example = "1"
+            )
             @PathVariable Long recommendationId,
+
             @Valid @RequestBody AiRoutineAddRequest request
     ) {
         return ApiResponse.ok(
@@ -61,11 +165,4 @@ import io.swagger.v3.oas.annotations.tags.Tag;
                 aiService.addRecommendedRoutines(userDetails, recommendationId, request)
         );
     }
-
-// 초기 코드 주석 처리
-//    @PostMapping("/generate")
-//    public ApiResponse<AiResponse> generate(@RequestBody AiRequest request) {
-//        AiResponse response = aiService.generate(request);
-//        return ApiResponse.ok("AI 응답 생성에 성공했습니다.", response);
-//    }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -1,8 +1,11 @@
 package com.rutina.rutinabackend.domain.ailog.repository;
 
 import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -13,4 +13,10 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
     List<AiLog> findByUser_Id(Long userId);
     //추가하기 버튼 눌렀을 때, 사용자가 선택한 optionId가 어떤 루틴 제목인지 알기 위함
     Optional<AiLog> findByIdAndUser_Id(Long id, Long userId);
+
+    long countByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+            Long userId,
+            OffsetDateTime start,
+            OffsetDateTime end
+    );
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -17,7 +17,7 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
     //추가하기 버튼 눌렀을 때, 사용자가 선택한 optionId가 어떤 루틴 제목인지 알기 위함
     Optional<AiLog> findByIdAndUser_Id(Long id, Long userId);
 
-    long countByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+    long countByUser_IdAndRequestTypeAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
             Long userId,
             String requestType,
             OffsetDateTime start,

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -16,6 +16,7 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
 
     long countByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
             Long userId,
+            String requestType,
             OffsetDateTime start,
             OffsetDateTime end
     );

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -125,42 +125,12 @@ public class AiService {
 
         String username = userDetails.getUsername();
 
-        try {
-            Long userId = Long.valueOf(username);
-
-            return userRepository.findById(userId)
-                    .orElseThrow(() -> new BusinessException(
-                            HttpStatus.NOT_FOUND,
-                            "USER_NOT_FOUND",
-                            "사용자를 찾을 수 없습니다."
-                    ));
-        } catch (NumberFormatException ignored) {
-            Long userId = findUserIdByEmail(username);
-
-            return userRepository.findById(userId)
-                    .orElseThrow(() -> new BusinessException(
-                            HttpStatus.NOT_FOUND,
-                            "USER_NOT_FOUND",
-                            "사용자를 찾을 수 없습니다."
-                    ));
-        }
-    }
-
-    // UserDetails.username이 email인 경우 users 테이블에서 id 조회
-    private Long findUserIdByEmail(String email) {
-        try {
-            return jdbcTemplate.queryForObject(
-                    "select id from users where email = ?",
-                    Long.class,
-                    email
-            );
-        } catch (EmptyResultDataAccessException e) {
-            throw new BusinessException(
-                    HttpStatus.NOT_FOUND,
-                    "USER_NOT_FOUND",
-                    "사용자를 찾을 수 없습니다."
-            );
-        }
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.NOT_FOUND,
+                        "USER_NOT_FOUND",
+                        "사용자를 찾을 수 없습니다."
+                ));
     }
 
     // AI 추천에 필요한 사용자 정보 검증
@@ -362,7 +332,7 @@ public class AiService {
         User user = getLoginUser(userDetails);
 
         validateDailyAiLimit(user.getId());
-        
+
         validateUserInfo(user);
         validateRequestOptions(request);
 

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -26,6 +26,8 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.rutina.rutinabackend.domain.ailog.constant.AiRoutineOptionConstants.*;
+
 @Service
 public class AiService {
     // 나중에 AI 기능이 여러 개로 늘어났을 때, 루틴 추천 로그만 구분하기 위해 사용한다.
@@ -34,52 +36,6 @@ public class AiService {
     //루틴 횟수 제한
     private static final int DAILY_AI_LIMIT = 3;
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
-
-    // 프론트에서 자유 입력 거부하고, 하단 선택지에서만 고르게 하기 위한 목록(임시)
-    private static final List<String> PURPOSES = List.of(
-            "건강 관리",
-            "자기계발",
-            "공부/집중",
-            "생활 습관 개선",
-            "취미 관리"
-    );
-
-    // 목적
-    private static final List<String> MAIN_ACTIVITY_TIMES = List.of(
-            "아침",
-            "오전",
-            "오후",
-            "저녁",
-            "밤"
-    );
-
-    // 루틴 활동 타입
-    private static final List<String> ACTIVITY_TYPES = List.of(
-            "실내 활동",
-            "야외 활동",
-            "정적인 활동",
-            "동적인 활동",
-            "혼자 하는 활동",
-            "함께 하는 활동"
-    );
-
-    // 취미
-    private static final List<String> HOBBIES = List.of(
-            "독서",
-            "운동",
-            "음악",
-            "영화/드라마",
-            "게임",
-            "요리",
-            "산책",
-            "일기",
-            "공부",
-            "청소/정리",
-            "없음"
-    );
-
-    // AI가 추천할 수 있는 루틴 소요 시간 목록
-    private static final List<Integer> ALLOWED_DURATIONS = List.of(10, 20, 30, 40, 50, 60);
 
     // 의존성 주입 필드
 

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -123,7 +123,15 @@ public class AiService {
             );
         }
 
-        String username = userDetails.getUsername();
+        try {
+            userId = Long.valueOf(userDetails.getUsername());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(
+                    HttpStatus.UNAUTHORIZED,
+                    "INVALID_AUTHENTICATION",
+                    "로그인 사용자 정보가 올바르지 않습니다."
+            );
+        }
 
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -1,21 +1,27 @@
 package com.rutina.rutinabackend.domain.ailog.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import com.rutina.rutinabackend.domain.ailog.dto.*;
 import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.exception.BusinessException;
+import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
+
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.http.HttpStatus;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,6 +30,10 @@ import java.util.stream.Collectors;
 public class AiService {
     // 나중에 AI 기능이 여러 개로 늘어났을 때, 루틴 추천 로그만 구분하기 위해 사용한다.
     private static final String REQUEST_TYPE_ROUTINE_RECOMMEND = "ROUTINE_RECOMMEND";
+
+    //루틴 횟수 제한
+    private static final int DAILY_AI_LIMIT = 3;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     // 프론트에서 자유 입력 거부하고, 하단 선택지에서만 고르게 하기 위한 목록(임시)
     private static final List<String> PURPOSES = List.of(
@@ -164,6 +174,36 @@ public class AiService {
                     HttpStatus.BAD_REQUEST,
                     "AI_PROFILE_INFO_REQUIRED",
                     "직업, 연령, 성별 정보를 입력해야 이용 가능한 서비스입니다."
+            );
+        }
+    }
+
+    // 계정당 하루 AI 추천 요청 횟수 제한
+    private void validateDailyAiLimit(Long userId) {
+        LocalDate today = LocalDate.now(KOREA_ZONE);
+
+        OffsetDateTime startOfToday = today
+                .atStartOfDay(KOREA_ZONE)
+                .toOffsetDateTime();
+
+        OffsetDateTime startOfTomorrow = today
+                .plusDays(1)
+                .atStartOfDay(KOREA_ZONE)
+                .toOffsetDateTime();
+
+        long todayCount = aiLogRepository
+                .countByUser_IdAndRequestTypeAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                        userId,
+                        REQUEST_TYPE_ROUTINE_RECOMMEND,
+                        startOfToday,
+                        startOfTomorrow
+                );
+
+        if (todayCount >= DAILY_AI_LIMIT) {
+            throw new BusinessException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    "AI_DAILY_LIMIT_EXCEEDED",
+                    "AI 추천은 하루에 3번까지만 요청할 수 있습니다."
             );
         }
     }
@@ -321,6 +361,8 @@ public class AiService {
     ) {
         User user = getLoginUser(userDetails);
 
+        validateDailyAiLimit(user.getId());
+        
         validateUserInfo(user);
         validateRequestOptions(request);
 

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -79,6 +79,8 @@ public class AiService {
             );
         }
 
+        Long userId;
+
         try {
             userId = Long.valueOf(userDetails.getUsername());
         } catch (NumberFormatException e) {
@@ -112,8 +114,18 @@ public class AiService {
         }
     }
 
+    // ADMIN 계정은 AI 요청 횟수 제한 제외
+    private boolean isAdmin(User user) {
+        return "ADMIN".equals(user.getRole());
+    }
+
+
     // 계정당 하루 AI 추천 요청 횟수 제한
-    private void validateDailyAiLimit(Long userId) {
+    private void validateDailyAiLimit(User user) {
+        if (isAdmin(user)) {
+            return;
+        }
+
         LocalDate today = LocalDate.now(KOREA_ZONE);
 
         OffsetDateTime startOfToday = today
@@ -127,7 +139,7 @@ public class AiService {
 
         long todayCount = aiLogRepository
                 .countByUser_IdAndRequestTypeAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
-                        userId,
+                        user.getId(),
                         REQUEST_TYPE_ROUTINE_RECOMMEND,
                         startOfToday,
                         startOfTomorrow
@@ -295,7 +307,7 @@ public class AiService {
     ) {
         User user = getLoginUser(userDetails);
 
-        validateDailyAiLimit(user.getId());
+        validateDailyAiLimit(user);
 
         validateUserInfo(user);
         validateRequestOptions(request);


### PR DESCRIPTION
## 관련 이슈

- Closes #62 

---

## 작업 내용

- AI 루틴 추천 일일 요청 제한 추가
  - 일반 사용자: 하루 3회 제한
  - ADMIN 계정: 제한 제외
  - 한국 시간 기준 매일 00:00 초기화

- AI 요청 횟수 조회 로직 추가
  - `AiLog.createdAt` 기준 조회
  - `requestType` 기준으로 AI 루틴 추천 요청만 카운트

- AI 추천 선택지 상수 분리
  - 목적
  - 주요 활동 시간
  - 활동 유형
  - 취미
  - 추천 소요 시간

- Swagger 문서 보강
  - 일일 요청 제한 설명 추가
  - 에러 응답 예시 추가
  - 추천 생성/선택지 조회/추천 루틴 추가 API 설명 보완


---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.