### PR TITLE
fix: OAuth redirect_uri 프로토콜 설정 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,6 +80,10 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+server:
+  # OAuth redirect_uri가 http://...가 아닌 https://rutina.co.kr/...로 생성되도록 필요합니다.
+  forward-headers-strategy: framework
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiry: 1800000       # 30분


### PR DESCRIPTION
## 관련 이슈

- Closes #64 

---

## 작업 내용

- 운영 도메인에서 OAuth redirect_uri가 `http`로 생성되던 문제 수정
- `server.forward-headers-strategy: framework` 설정 추가

---

## 테스트 체크리스트

- [ ] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
 배포 후에 문제 있을 시 Nginx 설청이 추가로 필요할 수 있습니다.