### PR TITLE
[Feat] 로컬 프로파일 Redis 분리 - RefreshTokenStore 인터페이스 도입

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -2,11 +2,9 @@ package com.rutina.rutinabackend.domain.user.service;
 
 import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
-import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
 import com.rutina.rutinabackend.domain.user.entity.User;
-import java.time.OffsetDateTime;
-import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenStore refreshTokenStore;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
@@ -56,11 +54,8 @@ public class AuthService {
         String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
 
-        // 같은 기기 재로그인 시 해당 기기 토큰만 교체 (다른 기기 토큰 유지)
-        refreshTokenRepository.deleteByUserIdAndDevice(user.getId(), device);
-        refreshTokenRepository.save(
-                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry(), device)
-        );
+        // getRefreshTokenExpiry()는 ms 단위, store 인터페이스는 seconds 단위
+        refreshTokenStore.save(user.getId(), device, refreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
 
         return LoginResponse.of(accessToken, refreshToken);
     }
@@ -74,28 +69,19 @@ public class AuthService {
             throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
         }
 
-        // DB에 저장된 토큰인지 확인
-        RefreshToken saved = refreshTokenRepository.findByTokenValue(request.refreshToken())
+        // empty → 존재하지 않거나 만료된 토큰 (prod 프로파일은 store 내부에서 DB expiresAt도 검증)
+        Long userId = refreshTokenStore.findUserIdByToken(request.refreshToken())
                 .orElseThrow(ErrorCode.INVALID_REFRESH_TOKEN::toException);
 
-        // DB expires_at 만료 검증
-        if (saved.getExpiresAt().isBefore(OffsetDateTime.now())) {
-            // 토근 삭제
-            refreshTokenRepository.delete(saved);
-            throw ErrorCode.INVALID_REFRESH_TOKEN.toException();
-        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
 
-        User user = saved.getUser();
-
-        // 새 토큰 발급 (rotation)
         String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
         String newRefreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
 
-        // 기존 토큰 교체
-        refreshTokenRepository.delete(saved);
-        refreshTokenRepository.save(
-                RefreshToken.of(user, newRefreshToken, jwtProvider.getRefreshTokenExpiry(), device)
-        );
+        // rotation: 구 토큰 폐기 후 새 토큰 등록
+        refreshTokenStore.deleteByToken(request.refreshToken());
+        refreshTokenStore.save(user.getId(), device, newRefreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
 
         return LoginResponse.of(newAccessToken, newRefreshToken);
     }
@@ -103,8 +89,7 @@ public class AuthService {
     // ── 로그아웃 ──────────────────────────────────────────────
     @Transactional // refreshToken으로 기기별 로그아웃
     public void logout(TokenRefreshRequest request) {
-        refreshTokenRepository.findByTokenValue(request.refreshToken())
-                .ifPresent(refreshTokenRepository::delete);
+        refreshTokenStore.deleteByToken(request.refreshToken());
     }
 
     // ── 이메일 중복 확인 ─────────────────────────

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/DbRefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/DbRefreshTokenStore.java
@@ -1,0 +1,50 @@
+package com.rutina.rutinabackend.global.auth.token;
+
+import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
+import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+@Profile("prod")
+@Component
+@RequiredArgsConstructor
+public class DbRefreshTokenStore implements RefreshTokenStore {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void save(Long userId, String device, String token, long ttlSeconds) {
+        User user = userRepository.findById(userId).orElseThrow();
+        refreshTokenRepository.deleteByUserIdAndDevice(userId, device);
+        // 인터페이스 계약은 seconds, RefreshToken.of()는 ms를 받으므로 *1000L 변환
+        refreshTokenRepository.save(RefreshToken.of(user, token, ttlSeconds * 1000L, device));
+    }
+
+    @Override
+    public Optional<Long> findUserIdByToken(String token) {
+        // JWT 서명 검증(호출자)과 별도로 DB expiresAt을 이중 검증 — 강제 폐기 시나리오 대응
+        return refreshTokenRepository.findByTokenValue(token)
+                .filter(rt -> rt.getExpiresAt().isAfter(OffsetDateTime.now()))
+                .map(rt -> rt.getUser().getId());
+    }
+
+    @Override
+    public void deleteByUserIdAndDevice(Long userId, String device) {
+        refreshTokenRepository.deleteByUserIdAndDevice(userId, device);
+    }
+
+    @Override
+    public void deleteByToken(String token) {
+        refreshTokenRepository.findByTokenValue(token)
+                .ifPresent(refreshTokenRepository::delete);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/InMemoryRefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/InMemoryRefreshTokenStore.java
@@ -1,0 +1,53 @@
+package com.rutina.rutinabackend.global.auth.token;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Profile("local")
+@Component
+public class InMemoryRefreshTokenStore implements RefreshTokenStore {
+
+    // token → userId (토큰값으로 userId 역조회)
+    private final Map<String, Long> tokenToUser = new ConcurrentHashMap<>();
+    // "userId:device" → token (기기별 단일 토큰 보장, 중복 로그인 시 이전 토큰 무효화용)
+    private final Map<String, String> userDeviceToToken = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Long userId, String device, String token, long ttlSeconds) {
+        String key = userId + ":" + device;
+        String existingToken = userDeviceToToken.get(key);
+        // 같은 기기로 재로그인하면 이전 토큰이 tokenToUser에 남아 역조회되는 것을 방지
+        if (existingToken != null) {
+            tokenToUser.remove(existingToken);
+        }
+        userDeviceToToken.put(key, token);
+        tokenToUser.put(token, userId);
+    }
+
+    @Override
+    public Optional<Long> findUserIdByToken(String token) {
+        return Optional.ofNullable(tokenToUser.get(token));
+    }
+
+    @Override
+    public void deleteByUserIdAndDevice(Long userId, String device) {
+        String key = userId + ":" + device;
+        String token = userDeviceToToken.remove(key);
+        if (token != null) {
+            tokenToUser.remove(token);
+        }
+    }
+
+    @Override
+    public void deleteByToken(String token) {
+        Long userId = tokenToUser.remove(token);
+        if (userId != null) {
+            // userDeviceToToken에 token → key 역방향 인덱스가 없으므로 value 스캔으로 제거
+            userDeviceToToken.entrySet().removeIf(e -> e.getValue().equals(token));
+        }
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/RefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/RefreshTokenStore.java
@@ -1,0 +1,10 @@
+package com.rutina.rutinabackend.global.auth.token;
+
+import java.util.Optional;
+
+public interface RefreshTokenStore {
+    void save(Long userId, String device, String token, long ttlSeconds);
+    Optional<Long> findUserIdByToken(String token);
+    void deleteByUserIdAndDevice(Long userId, String device);
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -1,9 +1,8 @@
 package com.rutina.rutinabackend.global.oauth2;
 
-import com.rutina.rutinabackend.domain.refreshToken.entity.RefreshToken;
-import com.rutina.rutinabackend.domain.refreshToken.repository.RefreshTokenRepository;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
@@ -26,7 +25,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenStore refreshTokenStore;
 
     @Value("${oauth2.redirect-url}")
     private String redirectUrl;
@@ -48,10 +47,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
 
-        refreshTokenRepository.deleteByUserIdAndDevice(user.getId(), device);
-        refreshTokenRepository.save(
-                RefreshToken.of(user, refreshToken, jwtProvider.getRefreshTokenExpiry(), device)
-        );
+        // getRefreshTokenExpiry()는 ms 단위, store 인터페이스는 seconds 단위
+        refreshTokenStore.save(user.getId(), device, refreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
 
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
                 .queryParam("accessToken", accessToken)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,6 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,11 +32,6 @@ spring:
         options:
           model: gpt-4o-mini
           temperature: 0.7
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
-
   # ── 소셜 로그인 ──────────────────────────────────────────
   security:
     oauth2:


### PR DESCRIPTION
## 관련 이슈

- Closes #66 

---

## 작업 내용

- `RefreshTokenStore` 인터페이스 추가 — `save` / `findUserIdByToken` / `deleteByUserIdAndDevice` / `deleteByToken` 4개 메서드 정의
- `InMemoryRefreshTokenStore` 추가 (`@Profile("local")`) — ConcurrentHashMap 듀얼맵으로 기기별 단일 토큰 보장, TTL 무시
- `DbRefreshTokenStore` 추가 (`@Profile("prod")`) — 기존 JPA 로직 이전, `expiresAt` 만료 이중 검증 포함
- `application-local.yaml` 추가 — Redis AutoConfiguration 3종 exclude (local 전용)
- `AuthService` — `RefreshTokenRepository` 직접 의존 제거, `RefreshTokenStore`로 교체
- `OAuth2SuccessHandler` — 동일하게 `RefreshTokenStore`로 교체
- `application.yaml` — Redis exclude 블록을 `application-local.yaml`로 이전하여 공통 설정에서 제거

---

## ConcurrentHashMap을 사용한 이유

로컬 환경에서 Redis 없이 Refresh Token을 관리하기 위해 Java 기본 자료구조인 `ConcurrentHashMap`을 사용했습니다.

일반 `HashMap`과 달리 `ConcurrentHashMap`은 멀티스레드 환경(여러 요청이 동시에 들어오는 웹 서버)에서 동시 읽기/쓰기가 안전하게 동작합니다.

저장 구조는 Map을 2개로 나눠 양방향 조회를 지원합니다.

- `tokenToUser` : token값 → userId (token으로 userId 역조회)
- `userDeviceToToken` : `"userId:device"` → token값 (기기별 단일 토큰 보장)

TTL은 로컬 개발 목적이므로 적용하지 않았으며, 앱 재시작 시 토큰이 초기화되는 것은 의도된 동작입니다.

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
  - [x] `local` 프로파일로 앱 기동 시 Redis 연결 시도 없이 정상 기동
  - [x] 로그인 → refresh token 발급 정상 동작
  - [x] 토큰 재발급 (rotation) 정상 동작
  - [x] 사용한 토큰으로 재발급 재시도 시 401 반환
  - [x] 로그아웃 후 재발급 시도 시 401 반환
  - [x] 앱 재시작 후 기존 토큰으로 재발급 시도 시 401 반환

---

## 참고사항

> `DbRefreshTokenStore`는 기존 `AuthService`에 있던 JPA 로직을 그대로 이전한 것으로, prod 동작은 변경 없습니다.
>
> 로컬 실행 시 `.env`에 `SPRING_PROFILES_ACTIVE=local` 설정이 필요합니다.