### PR TITLE
[Feat] 소셜 로그인 시 신규 가입 여부(isNewUser)를 프론트에 전달

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -41,27 +42,33 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 : userInfo.getEmail();
 
         // provider + providerId 기준으로 기존 회원 조회, 없으면 자동 가입
-        User user = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
-                .orElseGet(() -> {
-                    // 동일 이메일 계정 존재 시 예외 처리
-                    if (userRepository.existsByEmail(email)) {
-                        throw oauth2Error("An account with the same email already exists");
-                    }
+        Optional<User> existingUser = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId());
+        boolean isNewUser = existingUser.isEmpty();
 
-                    if (isBlank(userInfo.getNickname())) {
-                        throw oauth2Error("OAuth2 nickname is required");
-                    }
-                    return userRepository.save(
-                            User.createOAuth(
-                                    email,
-                                    userInfo.getNickname(),
-                                    userInfo.getProvider(),
-                                    userInfo.getProviderId()
-                            )
-                    );
-                });
+        User user;
+        if (isNewUser) {
+            // 동일 이메일 계정 존재 시 예외 처리
+            if (userRepository.existsByEmail(email)) {
+                throw oauth2Error("An account with the same email already exists");
+            }
+            if (isBlank(userInfo.getNickname())) {
+                throw oauth2Error("OAuth2 nickname is required");
+            }
+            user = userRepository.save(
+                    User.createOAuth(
+                            email,
+                            userInfo.getNickname(),
+                            userInfo.getProvider(),
+                            userInfo.getProviderId()
+                    )
+            );
+        } else {
+            user = existingUser.get();
+        }
+
         Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
         attributes.put("userId", user.getId());
+        attributes.put("isNewUser", isNewUser);
 
         return new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())),

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -39,6 +39,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     ) throws IOException, ServletException {
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
         Long userId = Long.valueOf(String.valueOf(oauth2User.getAttributes().get("userId")));
+        boolean isNewUser = Boolean.TRUE.equals(oauth2User.getAttributes().get("isNewUser"));
         String device = request.getHeader("User-Agent"); // 기기별 RefreshToken 관리용
 
         User user = userRepository.findById(userId)
@@ -54,6 +55,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .queryParam("tokenType", "Bearer")
+                .queryParam("isNewUser", isNewUser)
                 .build()
                 .toUriString();
 


### PR DESCRIPTION
## 관련 이슈

- Closes #69 

---

## 작업 내용

- `CustomOAuth2UserService` — `findByProviderAndProviderId()` 결과를 `Optional`로 받아 `isEmpty()`로 신규 가입 여부를 명시적으로 판별, `attributes`에 `isNewUser` 추가
- `OAuth2SuccessHandler` — redirect URL 쿼리 파라미터에 `isNewUser` 추가

---

## 참고사항

소셜 로그인은 가입과 로그인이 단일 플로우로 처리되어 프론트가 신규 가입 여부를 알 수 없었습니다. `isNewUser`를 redirect URL 쿼리 파라미터로 전달해 프론트가 온보딩 화면 라우팅 여부를 결정할 수 있도록 했습니다.

기존 `orElseGet` 람다 내부에서 side-effect로 판별하는 방식 대신, `Optional.isEmpty()`로 명시적으로 분기했습니다.