### PR TITLE
[Fix] 닉네임 입력 자리 수 제한

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Size;
 public record NicknameUpdateRequest(
         // 공백 닉네임은 허용하지 않고, 길이를 30자로 제한합니다.
         @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(max = 30, message = "닉네임은 30자 이하로 입력해주세요.")
+        @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")
         String nickname
-) {
-}
+) {}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/NicknameUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 // 닉네임 변경 요청에서 필요한 값만 받기 위한 DTO입니다.
 public record NicknameUpdateRequest(
-        // 공백 닉네임은 허용하지 않고, 길이를 30자로 제한합니다.
+        // 공백 닉네임은 허용하지 않고, 길이를 2~10자로 제한합니다.
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")
         String nickname


### PR DESCRIPTION
## 관련 이슈

- Closes #72 

---

## 작업 내용

- 요구사항에 따라 기존 닉네임 제한 수가 30 자에서 2~10자로 제한으로 수정하였습니다.

---

## 테스트 체크리스트

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.