### PR TITLE
[BugFix] daily_targets FK 제약조건 중복 문제 수정

### DIFF
--- a/src/main/resources/db/migration/V10__fix_cascade_delete_daily_targets.sql
+++ b/src/main/resources/db/migration/V10__fix_cascade_delete_daily_targets.sql
@@ -1,0 +1,2 @@
+ALTER TABLE daily_targets
+    DROP CONSTRAINT IF EXISTS rt_daily_targets_routine_id_fkey;


### PR DESCRIPTION
## 관련 이슈

- Closes #79 

---

## 작업 내용

- V10 마이그레이션 추가로 `rt_daily_targets_routine_id_fkey` (ON DELETE NO ACTION) 제약조건 제거
- V9에서 제약조건명 불일치(`rt_` 접두사 누락)로 인해 기존 FK가 DROP되지 않아 NO ACTION / CASCADE 제약조건이 중복 존재하던 문제 해결

---

## 참고사항

> 