### PR TITLE
[Feat] 숨김 해제 카테고리 정렬 순서 자동 배치

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
@@ -22,6 +22,9 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     // 내 카테고리 단건 조회
     Optional<Category> findByIdAndUser_Id(Long categoryId, Long userId);
 
+    // 숨김 해제 시 보이는 카테고리 중 가장 마지막 순서 조회
+    Optional<Category> findTopByUser_IdAndHiddenFalseOrderBySortOrderDescIdDesc(Long userId);
+
     // 생성 시 이름 중복 체크
     boolean existsByUser_IdAndName(Long userId, String name);
 

--- a/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/service/CategoryService.java
@@ -106,11 +106,29 @@ public class CategoryService {
             throw new BusinessException(HttpStatus.CONFLICT, "CATEGORY_409", "이미 같은 이름의 카테고리가 존재합니다.");
         }
 
-        category.update(
-                categoryName,
-                request.getColorCode(),
-                request.getHidden()
-        );
+        Boolean currentHidden = category.getHidden();
+        Boolean nextHidden = request.getHidden();
+
+        // hidden=true였던 카테고리를 hidden=false로 바꾸는 경우만 맨 뒤로 이동
+        if (Boolean.TRUE.equals(currentHidden) && Boolean.FALSE.equals(nextHidden)) {
+            int lastSortOrder = categoryRepository.findTopByUser_IdAndHiddenFalseOrderBySortOrderDescIdDesc(userId)
+                    .map(Category::getSortOrder)
+                    .orElse(-1);
+
+            category.update(
+                    categoryName,
+                    request.getColorCode(),
+                    false
+            );
+
+            category.updateSortOrder(lastSortOrder + 1);
+        } else {
+            category.update(
+                    categoryName,
+                    request.getColorCode(),
+                    nextHidden
+            );
+        }
 
         return CategoryResponse.from(category);
     }
@@ -120,7 +138,7 @@ public class CategoryService {
     // 그 순서대로 sortOrder를 다시 저장
     @Transactional
     public void updateCategoryOrder(Long userId, CategoryOrderUpdateRequest request) {
-        List<Category> categories = categoryRepository.findAllByUser_IdOrderBySortOrderAscIdAsc(userId);
+        List<Category> categories = categoryRepository.findAllByUser_IdAndHiddenFalseOrderBySortOrderAscIdAsc(userId);
         List<Long> requestIds = request.getCategoryIds();
 
         // 사용자의 전체 카테고리 개수와 요청 개수가 다르면 잘못된 요청


### PR DESCRIPTION
## 관련 이슈

- Closes #84 

---

## 작업 내용

- 숨김 상태였던 카테고리를 다시 표시할 때 현재 노출 중인 카테고리 목록의 맨 뒤로 배치되도록 수정
- 숨김 해제 시 `hidden=true → hidden=false` 상태 변경인 경우에만 `sortOrder`를 재계산하도록 처리
- 카테고리 순서 변경 API에서 전체 카테고리가 아닌 `hidden=false` 카테고리만 기준으로 검증하도록 수정
- reorder 요청 시 프론트에서 숨김 처리되지 않은 카테고리 id만 전달해도 정상 처리되도록 변경
- 보이는 카테고리 중 가장 마지막 `sortOrder`를 조회하는 Repository 메서드 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.