### PR TITLE
[Feat] 루틴 완료 히트맵 조회

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/dailytarget/repository/DailyTargetRepository.java
@@ -13,4 +13,11 @@ public interface DailyTargetRepository extends JpaRepository<DailyTarget, Long> 
     List<DailyTarget> findByRoutineId(Long routineId);
     Optional<DailyTarget> findByRoutineIdAndTargetDate(Long routineId, LocalDate targetDate);
     List<DailyTarget> findByRoutineIdInAndTargetDate(List<Long> routineIds, LocalDate targetDate);
+
+    // 여러 루틴의 기간 내 완료된 기록만 조회
+    List<DailyTarget> findByRoutineIdInAndTargetDateBetweenAndIsCompletedTrue(
+            List<Long> routineIds,
+            LocalDate startDate,
+            LocalDate endDate
+    );
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/controller/RoutineController.java
@@ -1,6 +1,7 @@
 package com.rutina.rutinabackend.domain.routine.controller;
 
 import com.rutina.rutinabackend.domain.routine.dto.RoutineCreateRequest;
+import com.rutina.rutinabackend.domain.routine.dto.RoutineHeatmapResponse;
 import com.rutina.rutinabackend.domain.routine.dto.RoutineResponse;
 import com.rutina.rutinabackend.domain.routine.dto.RoutineTimetableResponse;
 import com.rutina.rutinabackend.domain.routine.dto.RoutineUpdateRequest;
@@ -14,7 +15,16 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -48,7 +58,6 @@ public class RoutineController {
             @RequestParam(required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        // categoryId, date 모두 optional이며 4가지 조합(null/null, null/값, 값/null, 값/값) 모두 동작
         Long userId = Long.parseLong(userDetails.getUsername());
 
         List<RoutineResponse> response = routineService.getRoutines(userId, categoryId, date);
@@ -61,11 +70,35 @@ public class RoutineController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        // date는 required=true(기본값)이므로 미전송 시 Spring이 자동으로 400 반환
         Long userId = Long.parseLong(userDetails.getUsername());
 
         List<RoutineTimetableResponse> response = routineService.getTimetable(userId, date);
         return ApiResponse.ok("타임테이블 조회에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "루틴별 연간 완료 히트맵 조회")
+    @GetMapping("/heatmap/year")
+    public ApiResponse<List<RoutineHeatmapResponse>> getYearHeatmap(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam int year
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<RoutineHeatmapResponse> response = routineService.getYearHeatmap(userId, year);
+        return ApiResponse.ok("루틴별 연간 완료 히트맵 조회에 성공했습니다.", response);
+    }
+
+    @Operation(summary = "루틴별 월간 완료 히트맵 조회")
+    @GetMapping("/heatmap/month")
+    public ApiResponse<List<RoutineHeatmapResponse>> getMonthHeatmap(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<RoutineHeatmapResponse> response = routineService.getMonthHeatmap(userId, year, month);
+        return ApiResponse.ok("루틴별 월간 완료 히트맵 조회에 성공했습니다.", response);
     }
 
     @Operation(summary = "루틴 단건 조회")
@@ -74,7 +107,6 @@ public class RoutineController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long routineId
     ) {
-        // path variable로 받은 routineId와 로그인 userId를 함께 사용해서 본인 루틴만 조회 가능하도록 처리
         Long userId = Long.parseLong(userDetails.getUsername());
 
         RoutineResponse response = routineService.getRoutine(userId, routineId);

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/controller/RoutineController.java
@@ -101,6 +101,18 @@ public class RoutineController {
         return ApiResponse.ok("루틴별 월간 완료 히트맵 조회에 성공했습니다.", response);
     }
 
+    @Operation(summary = "루틴별 주간 완료 히트맵 조회")
+    @GetMapping("/heatmap/week")
+    public ApiResponse<List<RoutineHeatmapResponse>> getWeekHeatmap(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        List<RoutineHeatmapResponse> response = routineService.getWeekHeatmap(userId, date);
+        return ApiResponse.ok("루틴별 주간 완료 히트맵 조회에 성공했습니다.", response);
+    }
+
     @Operation(summary = "루틴 단건 조회")
     @GetMapping("/{routineId}")
     public ApiResponse<RoutineResponse> getRoutine(

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapCategoryResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapCategoryResponse.java
@@ -1,0 +1,22 @@
+package com.rutina.rutinabackend.domain.routine.dto;
+
+import com.rutina.rutinabackend.domain.category.entity.Category;
+
+public record RoutineHeatmapCategoryResponse(
+        Long id,
+        String name,
+        String colorCode
+) {
+    // 카테고리가 없는 루틴은 null로 응답
+    public static RoutineHeatmapCategoryResponse from(Category category) {
+        if (category == null) {
+            return null;
+        }
+
+        return new RoutineHeatmapCategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getColorCode()
+        );
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapResponse.java
@@ -1,0 +1,22 @@
+package com.rutina.rutinabackend.domain.routine.dto;
+
+import com.rutina.rutinabackend.domain.routine.entity.Routine;
+
+import java.util.Map;
+
+public record RoutineHeatmapResponse(
+        Long routineId,
+        String title,
+        RoutineHeatmapCategoryResponse category,
+        Map<String, Boolean> completed
+) {
+    // completed에는 완료된 날짜 키만 true로 포함
+    public static RoutineHeatmapResponse from(Routine routine, Map<String, Boolean> completed) {
+        return new RoutineHeatmapResponse(
+                routine.getId(),
+                routine.getTitle(),
+                RoutineHeatmapCategoryResponse.from(routine.getCategory()),
+                completed
+        );
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
@@ -16,6 +16,10 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     // 전체 목록 조회
     List<Routine> findByUserId(Long userId);
 
+    // 히트맵 응답에 카테고리 색상 정보가 필요하므로 category를 함께 조회
+    @Query("SELECT r FROM Routine r LEFT JOIN FETCH r.category WHERE r.user.id = :userId")
+    List<Routine> findByUserIdWithCategory(@Param("userId") Long userId);
+
     // 카테고리별 조회
     List<Routine> findByUserIdAndCategoryId(Long userId, Long categoryId);
 

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -169,6 +170,14 @@ public class RoutineService {
         LocalDate endDate = yearMonth.atEndOfMonth();
 
         return getHeatmap(userId, startDate, endDate, date -> String.valueOf(date.getDayOfMonth()));
+    }
+
+    // 주간 히트맵: 기준 날짜가 포함된 일~토 7일 중 완료 기록이 있는 날짜만 true로 표시
+    public List<RoutineHeatmapResponse> getWeekHeatmap(Long userId, LocalDate date) {
+        LocalDate startDate = date.with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SUNDAY));
+        LocalDate endDate = startDate.plusDays(6);
+
+        return getHeatmap(userId, startDate, endDate, LocalDate::toString);
     }
 
     // ── 루틴 수정 ─────────────────────────────────────────────────

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
@@ -17,13 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -147,6 +150,27 @@ public class RoutineService {
                 .collect(Collectors.toList());
     }
 
+    // 연간 히트맵: 완료 기록이 있는 날짜만 true로 표시
+    public List<RoutineHeatmapResponse> getYearHeatmap(Long userId, int year) {
+        LocalDate startDate = LocalDate.of(year, 1, 1);
+        LocalDate endDate = LocalDate.of(year, 12, 31);
+
+        return getHeatmap(userId, startDate, endDate, LocalDate::toString);
+    }
+
+    // 월간 히트맵: 완료 기록이 있는 일자만 true로 표시
+    public List<RoutineHeatmapResponse> getMonthHeatmap(Long userId, int year, int month) {
+        if (month < 1 || month > 12) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "ROUTINE_400", "월은 1부터 12 사이여야 합니다.");
+        }
+
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        return getHeatmap(userId, startDate, endDate, date -> String.valueOf(date.getDayOfMonth()));
+    }
+
     // ── 루틴 수정 ─────────────────────────────────────────────────
     @Transactional
     public RoutineResponse updateRoutine(Long userId, Long routineId, RoutineUpdateRequest request) {
@@ -197,6 +221,45 @@ public class RoutineService {
     public void deleteRoutine(Long userId, Long routineId) {
         Routine routine = findRoutine(userId, routineId);
         routineRepository.delete(routine);
+    }
+
+    // 루틴별 완료 기록을 조회 기간에 맞는 키(날짜 또는 일자)로 묶어 응답 생성
+    private List<RoutineHeatmapResponse> getHeatmap(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Function<LocalDate, String> keyExtractor
+    ) {
+        List<Routine> routines = routineRepository.findByUserIdWithCategory(userId);
+        if (routines.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> routineIds = routines.stream()
+                .map(Routine::getId)
+                .toList();
+
+        // 같은 날짜에 완료 기록이 여러 개여도 true 하나만 유지
+        Map<Long, Map<String, Boolean>> completedMap = dailyTargetRepository
+                .findByRoutineIdInAndTargetDateBetweenAndIsCompletedTrue(routineIds, startDate, endDate)
+                .stream()
+                .sorted(Comparator.comparing(DailyTarget::getTargetDate))
+                .collect(Collectors.groupingBy(
+                        dailyTarget -> dailyTarget.getRoutine().getId(),
+                        Collectors.toMap(
+                                dailyTarget -> keyExtractor.apply(dailyTarget.getTargetDate()),
+                                dailyTarget -> true,
+                                (first, second) -> true,
+                                LinkedHashMap::new
+                        )
+                ));
+
+        return routines.stream()
+                .map(routine -> RoutineHeatmapResponse.from(
+                        routine,
+                        completedMap.getOrDefault(routine.getId(), Map.of())
+                ))
+                .toList();
     }
 
     // ── 시간 겹침 검사 ─────────────────────────────────────────────


### PR DESCRIPTION
## 관련 이슈

- Closes #81 

---

## 작업 내용

- RoutineHeatmapCategoryResponse DTO 추가 — 루틴 히트맵 응답에 필요한 카테고리 id, name, colorCode 반환
- RoutineHeatmapResponse DTO 추가 — 루틴별 히트맵 데이터와 completed 날짜 map 반환
- DailyTargetRepository에 완료 기록 기간 조회 메서드 추가 — 지정 기간 내 isCompleted=true 기록만 조회
- RoutineRepository에 category fetch join 조회 메서드 추가 — 히트맵 응답에 필요한 카테고리 색상 정보 함께 조회
- RoutineService에 루틴별 완료 히트맵 집계 로직 추가 — Year는 yyyy-MM-dd 날짜별, Month는 해당 월 일자별 true 값만 반환
- GET /api/v1/routines/heatmap/year 엔드포인트 구현
- GET /api/v1/routines/heatmap/month 엔드포인트 구현
---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
Year 모드는 GitHub 잔디처럼 yyyy-MM-dd 키로 반환하고, Month 모드는 선택한 월의 일자 키로 반환합니다.