### PR TITLE
[Feat] 계정 탈퇴 기능 구현 (소셜/로컬 통합, AI 로그 익명화, soft delete)

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/RutinaBackendApplication.java
+++ b/src/main/java/com/rutina/rutinabackend/RutinaBackendApplication.java
@@ -2,8 +2,10 @@ package com.rutina.rutinabackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class RutinaBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/entity/AiLog.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/entity/AiLog.java
@@ -17,10 +17,12 @@ public class AiLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 탈퇴 처리 시 레코드 자체는 보존하고 user_id만 null로 익명화 (개인정보 분리 정책)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
+    // 루틴 삭제 전 routine_id를 null로 익명화하여 AI 로그 이력 보존
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_id")
     private Routine routine;

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -3,6 +3,9 @@ package com.rutina.rutinabackend.domain.ailog.repository;
 import com.rutina.rutinabackend.domain.ailog.entity.AiLog;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
@@ -23,4 +26,14 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
             OffsetDateTime start,
             OffsetDateTime end
     );
+
+    // 루틴 삭제 전 먼저 호출 필수
+    @Modifying
+    @Query("UPDATE AiLog a SET a.routine = null WHERE a.routine.id IN :routineIds")
+    void anonymizeByRoutineIds(@Param("routineIds") List<Long> routineIds);
+
+    // 유저 삭제 전 먼저 호출 필수
+    @Modifying
+    @Query("UPDATE AiLog a SET a.user = null WHERE a.user.id = :userId")
+    void anonymizeByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/category/repository/CategoryRepository.java
@@ -30,4 +30,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     // 수정 시 자기 자신 제외 이름 중복 체크
     boolean existsByUser_IdAndNameAndIdNot(Long userId, String name, Long categoryId);
+
+    void deleteAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -14,4 +14,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     @Transactional
     void deleteByUserIdAndDevice(Long userId, String device);
+
+    @Transactional
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/repository/RoutineRepository.java
@@ -42,4 +42,9 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     long countByUserIdAndCategoryId(Long userId, Long categoryId);
 
     void deleteByUserIdAndCategoryId(Long userId, Long categoryId);
+
+    @Query("SELECT r.id FROM Routine r WHERE r.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -85,5 +86,18 @@ public class UserController {
     public ApiResponse<Void> resetPassword(@Valid @RequestBody PasswordResetRequest request) {
         userService.resetPassword(request.email(), request.newPassword());
         return ApiResponse.ok("비밀번호가 재설정되었습니다.", null);
+    }
+
+    @Operation(
+            summary = "계정 탈퇴",
+            description = "로컬/소셜 계정 모두 즉시 탈퇴됩니다. 루틴, 카테고리, 완료 기록이 모두 삭제됩니다."
+    )
+    @DeleteMapping("/me")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        userService.withdrawUser(userId);
+        return ApiResponse.ok("계정이 삭제되었습니다.", null);
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -97,4 +97,10 @@ public class User {
         this.updatedAt = OffsetDateTime.now();
     }
 
+    // 실제 레코드 삭제가 아닌 deleted_at 시각 기록
+    public void softDelete() {
+        this.deletedAt = OffsetDateTime.now();
+        this.updatedAt = OffsetDateTime.now();
+    }
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/repository/UserRepository.java
@@ -1,9 +1,14 @@
 package com.rutina.rutinabackend.domain.user.repository;
 
 import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +19,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    // soft delete된 유저까지 포함하여 조회
+    @Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
+    Optional<User> findByEmailIncludingDeleted(@Param("email") String email);
+
+    // deleted_at이 cutoff 이전인 탈퇴 유저를 완전 삭제
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM users WHERE deleted_at IS NOT NULL AND deleted_at < :cutoff", nativeQuery = true)
+    int deleteWithdrawnBefore(@Param("cutoff") OffsetDateTime cutoff);
 
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -27,10 +27,14 @@ public class AuthService {
     @Transactional
     public LoginResponse signUp(SignUpRequest request, String device) {
 
-        // 이메일 중복 확인
-        if (userRepository.existsByEmail(request.email())) {
+        // 탈퇴 후 7일 보관 중인 계정은 조회하지 못함.
+        userRepository.findByEmailIncludingDeleted(request.email()).ifPresent(existing -> {
+            if (existing.getDeletedAt() != null) {
+                // 탈퇴한 계정 — 7일 보관 중
+                throw ErrorCode.WITHDRAWN_USER.toException();
+            }
             throw ErrorCode.DUPLICATE_EMAIL.toException();
-        }
+        });
 
         // 이메일 인증 완료 확인
         emailVerificationService.checkVerified(request.email());

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
@@ -1,6 +1,9 @@
 package com.rutina.rutinabackend.domain.user.service;
 
+import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
+import com.rutina.rutinabackend.domain.category.repository.CategoryRepository;
 import com.rutina.rutinabackend.domain.email.service.EmailVerificationService;
+import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
 import com.rutina.rutinabackend.domain.user.dto.PasswordChangeRequest;
@@ -8,11 +11,14 @@ import com.rutina.rutinabackend.domain.user.dto.UserProfileUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.UserResponse;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +27,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationService emailVerificationService;
+    private final RoutineRepository routineRepository;
+    private final CategoryRepository categoryRepository;
+    private final AiLogRepository aiLogRepository;
+    private final RefreshTokenStore refreshTokenStore;
 
     @Transactional(readOnly = true)
     public UserResponse getMe(Long userId) {
@@ -85,5 +95,32 @@ public class UserService {
         user.changePassword(passwordEncoder.encode(newPassword));
 
         emailVerificationService.clearPasswordResetVerified(email);
+    }
+
+    @Transactional
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+
+        // ai_logs.routine_id → null (루틴 삭제 전)
+        List<Long> routineIds = routineRepository.findIdsByUserId(userId);
+        if (!routineIds.isEmpty()) {
+            aiLogRepository.anonymizeByRoutineIds(routineIds);
+        }
+
+        // ai_logs.user_id → null (유저 삭제 전)
+        aiLogRepository.anonymizeByUserId(userId);
+
+        // routines 삭제 (daily_targets는 CASCADE로 자동 삭제)
+        routineRepository.deleteAllByUserId(userId);
+
+        // categories 삭제
+        categoryRepository.deleteAllByUser_Id(userId);
+
+        // refresh token 삭제
+        refreshTokenStore.deleteAllByUserId(userId);
+
+        // user soft delete (users 레코드는 7일 보관 후 스케줄러가 완전 삭제)
+        user.softDelete();
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/DbRefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/DbRefreshTokenStore.java
@@ -47,4 +47,9 @@ public class DbRefreshTokenStore implements RefreshTokenStore {
         refreshTokenRepository.findByTokenValue(token)
                 .ifPresent(refreshTokenRepository::delete);
     }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/InMemoryRefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/InMemoryRefreshTokenStore.java
@@ -50,4 +50,16 @@ public class InMemoryRefreshTokenStore implements RefreshTokenStore {
             userDeviceToToken.entrySet().removeIf(e -> e.getValue().equals(token));
         }
     }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String prefix = userId + ":";
+        userDeviceToToken.entrySet().removeIf(e -> {
+            if (e.getKey().startsWith(prefix)) {
+                tokenToUser.remove(e.getValue());
+                return true;
+            }
+            return false;
+        });
+    }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/RedisRefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/RedisRefreshTokenStore.java
@@ -66,6 +66,21 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
         redisTemplate.delete(TOKEN_KEY_PREFIX + token);
     }
 
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String pattern = DEVICE_KEY_PREFIX + userId + ":*";
+        Set<String> deviceKeys = redisTemplate.keys(pattern);
+        if (deviceKeys != null) {
+            deviceKeys.forEach(deviceKey -> {
+                String token = redisTemplate.opsForValue().get(deviceKey);
+                if (token != null) {
+                    redisTemplate.delete(TOKEN_KEY_PREFIX + token);
+                }
+                redisTemplate.delete(deviceKey);
+            });
+        }
+    }
+
     private String deviceKey(Long userId, String device) {
         return DEVICE_KEY_PREFIX + userId + ":" + device;
     }

--- a/src/main/java/com/rutina/rutinabackend/global/auth/token/RefreshTokenStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/token/RefreshTokenStore.java
@@ -7,4 +7,5 @@ public interface RefreshTokenStore {
     Optional<Long> findUserIdByToken(String token);
     void deleteByUserIdAndDevice(Long userId, String device);
     void deleteByToken(String token);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_REQUIRED(HttpStatus.FORBIDDEN, "AUTH_008", "이메일 인증이 필요합니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH_009", "인증번호가 올바르지 않거나 만료되었습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_010", "이메일 발송에 실패했습니다."),
+    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH_013", "탈퇴한 계정입니다. 7일 후 재가입이 가능합니다."),
 
     // 루틴
     ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE_001", "루틴을 찾을 수 없습니다."),

--- a/src/main/java/com/rutina/rutinabackend/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,28 @@
+package com.rutina.rutinabackend.global.scheduler;
+
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매일 자정(00:00) 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void deleteWithdrawnUsers() {
+        // cutoff(현재 시각 - 7일): deleted_at이 이보다 이른 탈퇴 유저를 영구 삭제
+        OffsetDateTime cutoff = OffsetDateTime.now().minusDays(7);
+        int deleted = userRepository.deleteWithdrawnBefore(cutoff);
+        log.info("[UserCleanupScheduler] 탈퇴 유저 완전 삭제 완료: {}명", deleted);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #83 

---

## 작업 내용

- UserCleanupScheduler 추가 — 매일 자정 deleted_at 기준 7일 경과 탈퇴 유저 영구 삭제
- User.softDelete() 추가 — 탈퇴 시 즉시 삭제 대신 deleted_at 기록 후 7일 보관
- UserRepository에 탈퇴 계정 포함 이메일 조회 및 벌크 삭제 메서드 추가 — @SQLRestriction 우회 nativeQuery로 처리
- AuthService.signUp() 탈퇴 계정 재가입 차단 — 7일 보관 중인 계정 감지 후 WITHDRAWN_USER 에러 반환
- RefreshTokenStore 인터페이스 및 InMemory·Redis·DB 구현체에 전 기기 토큰 일괄 폐기 메서드 추가
- AiLogRepository에 익명화 메서드 추가 — 탈퇴 시 ai_logs의 user_id·routine_id를 null로 처리하여 로그 데이터 보존
- RoutineRepository에 유저별 ID 조회 및 일괄 삭제 메서드 추가
- CategoryRepository에 유저별 일괄 삭제 메서드 추가
- UserService.withdrawUser() 구현 — 소셜/로컬 구분 없이 추가 인증 없이 탈퇴, FK 제약 순서에 맞게 데이터 일괄 삭제

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료

---

## 참고사항

> **삭제 순서 주의**: ai_logs.routine_id → null → ai_logs.user_id → null → routines 삭제 → categories 삭제 → refresh tokens 삭제 → user soft delete 순으로 처리. FK 제약 위반 방지를 위해 순서가 중요함.
>
> **soft delete 동작**: 탈퇴 시 users 레코드는 즉시 삭제되지 않고 deleted_at만 기록됨. @SQLRestriction("deleted_at IS NULL")으로 인해 탈퇴 유저는 일반 조회에서 자동 필터링되며, 재가입 차단은 nativeQuery로 우회하여 처리함.