### PR TITLE
[Feat] 애플 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     // ── Security & OAuth2 ─────────────────────────────────
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly    'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly    'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -45,6 +45,17 @@ public class AuthController {
         return ApiResponse.ok("로그인에 성공했습니다.", response);
     }
 
+    @Operation(summary = "Apple 로그인")
+    @SecurityRequirements({})
+    @PostMapping("/apple")
+    public ApiResponse<LoginResponse> appleLogin(@RequestBody @Valid AppleLoginRequest request,
+                                                 HttpServletRequest httpRequest) {
+        // React Native 앱에서 받은 Apple identityToken을 검증하고 기존 JWT 응답 형식으로 반환합니다.
+        String device = httpRequest.getHeader("User-Agent");
+        LoginResponse response = authService.loginWithApple(request, device);
+        return ApiResponse.ok("Apple 로그인에 성공했습니다.", response);
+    }
+
     @Operation(summary = "토큰 재발급")
     @SecurityRequirements({})
     @PostMapping("/reissue")

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/AppleLoginRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/AppleLoginRequest.java
@@ -1,0 +1,14 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginRequest(
+
+        @NotBlank(message = "Apple identity token은 필수입니다.")
+        String identityToken,
+
+        String email,
+
+        String nickname
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -5,13 +5,16 @@ import com.rutina.rutinabackend.domain.refreshToken.dto.TokenRefreshRequest;
 import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.auth.apple.AppleIdentityTokenVerifier;
 import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final EmailVerificationService emailVerificationService;
+    private final AppleIdentityTokenVerifier appleIdentityTokenVerifier;
 
     // ── 회원가입 ───────────────────────────────────────────
     @Transactional
@@ -113,5 +117,67 @@ public class AuthService {
     @Transactional(readOnly = true)
     public boolean checkEmailDuplicate(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public LoginResponse loginWithApple(AppleLoginRequest request, String device) {
+        // Apple identityToken의 서명, 발급자, 대상 앱(Bundle ID)을 검증합니다.
+        Jwt appleToken = appleIdentityTokenVerifier.verify(request.identityToken());
+        String providerId = appleToken.getSubject();
+
+        // Apple의 고유 사용자 식별자(sub)를 providerId로 사용해 기존 계정을 찾습니다.
+        User user = userRepository.findByProviderAndProviderId("APPLE", providerId)
+                .orElseGet(() -> createAppleUser(request, appleToken, providerId));
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
+
+        refreshTokenStore.save(user.getId(), device, refreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
+
+        return LoginResponse.of(accessToken, refreshToken);
+    }
+
+    private User createAppleUser(AppleLoginRequest request, Jwt appleToken, String providerId) {
+        String email = resolveAppleEmail(request, appleToken, providerId);
+
+        // 탈퇴 보관 계정과 기존 이메일 계정은 Apple 신규 가입으로 덮어쓰지 않습니다.
+        userRepository.findByEmailIncludingDeleted(email).ifPresent(existing -> {
+            if (existing.getDeletedAt() != null) {
+                throw ErrorCode.WITHDRAWN_USER.toException();
+            }
+            throw ErrorCode.SOCIAL_ACCOUNT_CONFLICT.toException();
+        });
+
+        String nickname = resolveAppleNickname(request, email);
+        User user = User.createOAuth(email, nickname, "APPLE", providerId);
+        return userRepository.save(user);
+    }
+
+    private String resolveAppleEmail(AppleLoginRequest request, Jwt appleToken, String providerId) {
+        // Apple email/name은 최초 로그인 때만 내려올 수 있어 앱에서 전달한 값을 우선 사용합니다.
+        if (StringUtils.hasText(request.email())) {
+            return request.email();
+        }
+
+        String tokenEmail = appleToken.getClaimAsString("email");
+        if (StringUtils.hasText(tokenEmail)) {
+            return tokenEmail;
+        }
+
+        return "apple_" + providerId + "@social.local";
+    }
+
+    private String resolveAppleNickname(AppleLoginRequest request, String email) {
+        // 이름을 받지 못한 경우 이메일 앞부분을 기본 닉네임으로 사용합니다.
+        if (StringUtils.hasText(request.nickname())) {
+            return request.nickname();
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex > 0) {
+            return email.substring(0, atIndex);
+        }
+
+        return "Apple User";
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/auth/apple/AppleIdentityTokenVerifier.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/apple/AppleIdentityTokenVerifier.java
@@ -1,0 +1,72 @@
+package com.rutina.rutinabackend.global.auth.apple;
+
+import com.rutina.rutinabackend.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Component
+public class AppleIdentityTokenVerifier {
+
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final String APPLE_JWK_SET_URI = "https://appleid.apple.com/auth/keys";
+
+    private final JwtDecoder jwtDecoder;
+    private final String bundleId;
+
+    public AppleIdentityTokenVerifier(@Value("${apple.bundle-id:}") String bundleId) {
+        this.bundleId = bundleId;
+
+        // Apple 공개키로 identityToken 서명을 검증하고 issuer/audience 조건을 함께 확인합니다.
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(APPLE_JWK_SET_URI).build();
+        OAuth2TokenValidator<Jwt> audienceValidator = new JwtClaimValidator<List<String>>(
+                "aud",
+                audiences -> StringUtils.hasText(bundleId) && audiences != null && audiences.contains(bundleId)
+        );
+        OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(
+                JwtValidators.createDefaultWithIssuer(APPLE_ISSUER),
+                audienceValidator
+        );
+
+        decoder.setJwtValidator(jwt -> {
+            OAuth2TokenValidatorResult result = validator.validate(jwt);
+            if (result.hasErrors()) {
+                return result;
+            }
+
+            if (!StringUtils.hasText(jwt.getSubject())) {
+                return OAuth2TokenValidatorResult.failure(
+                        new OAuth2Error("invalid_token", "Apple identity token subject is missing", null)
+                );
+            }
+
+            return OAuth2TokenValidatorResult.success();
+        });
+        this.jwtDecoder = decoder;
+    }
+
+    public Jwt verify(String identityToken) {
+        // Bundle ID가 설정되지 않은 환경에서는 Apple 토큰을 신뢰하지 않습니다.
+        if (!StringUtils.hasText(bundleId)) {
+            throw ErrorCode.INVALID_APPLE_IDENTITY_TOKEN.toException();
+        }
+
+        try {
+            return jwtDecoder.decode(identityToken);
+        } catch (JwtException e) {
+            throw ErrorCode.INVALID_APPLE_IDENTITY_TOKEN.toException();
+        }
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH_009", "인증번호가 올바르지 않거나 만료되었습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_010", "이메일 발송에 실패했습니다."),
     WITHDRAWN_USER(HttpStatus.FORBIDDEN, "AUTH_013", "탈퇴한 계정입니다. 7일 후 재가입이 가능합니다."),
+    INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_014", "유효하지 않은 Apple identity token입니다."),
+    SOCIAL_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "AUTH_015", "이미 다른 로그인 방식으로 가입된 이메일입니다."),
 
     // 루틴
     ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE_001", "루틴을 찾을 수 없습니다."),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,6 +94,9 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+apple:
+  bundle-id: ${APPLE_BUNDLE_ID:}
+
 server:
   # OAuth redirect_uri가 http://...가 아닌 https://rutina.co.kr/...로 생성되도록 필요합니다.
   forward-headers-strategy: framework


### PR DESCRIPTION
## 관련 이슈

- Closes #82 

---

## 작업 내용

- Apple identityToken 검증 로직 추가
- Apple 로그인 API 추가
- Apple 로그인 성공 시 기존 JWT 발급 흐름 연동
- Apple 신규 회원 생성 및 이메일 중복/탈퇴 계정 예외 처리 추가
- Apple Bundle ID 서버 환경변수 설정 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
React Native 앱에서 Apple 로그인 성공 후 전달하는 identityToken을 검증해 서비스 JWT를 발급합니다.