### PR TITLE
[Bugfix] 소셜 로그인 탈퇴 계정 이메일 중복 검사 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -48,11 +48,16 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         User user;
         if (isNewUser) {
             // 동일 이메일 계정 존재 시 예외 처리
-            if (userRepository.existsByEmail(email)) {
-                throw oauth2Error("An account with the same email already exists");
-            }
+            // 로컬 회원가입과 동일하게 탈퇴 계정의 재가입 제한을 적용합니다.
+            userRepository.findByEmailIncludingDeleted(email).ifPresent(existing -> {
+                if (existing.getDeletedAt() != null) {
+                    throw oauth2Error("탈퇴한 계정은 7일 동안 재가입할 수 없습니다.");
+                }
+                throw oauth2Error("이미 사용 중인 이메일입니다.");
+            });
+
             if (isBlank(userInfo.getNickname())) {
-                throw oauth2Error("OAuth2 nickname is required");
+                throw oauth2Error("소셜 계정의 닉네임 정보가 필요합니다.");
             }
             user = userRepository.save(
                     User.createOAuth(


### PR DESCRIPTION
## 관련 이슈

- Closes #98

---

## 작업 내용

- 소셜 로그인 신규 가입 시 탈퇴 계정까지 포함해 이메일 중복 여부를 확인하도록 수정했습니다.
- 탈퇴한 계정의 이메일로 소셜 가입을 시도할 경우 재가입 제한 메시지를 반환하도록 처리했습니다.

---

## 테스트 체크리스트

- [ ] 로컬 테스트 완료
- [ ] 기존 기능 정상 동작 확인
- [ ] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.
탈퇴 계정의 이메일로 소셜 가입을 시도하면 비즈니스 예외가 아닌 DB unique 제약 충돌이 발생할 수 있어 로컬 회원가입과 동일한 정책으로 맞췄습니다.