### PR TITLE
feat: 루틴 목록 조회 응답에 isExpired 필드 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
@@ -29,6 +29,14 @@ public class RoutineResponse {
     private LocalDate startAt;
     private LocalDate endAt;
     private Boolean isCompleted;        // date 없는 조회 시 null, date 있는 조회 시 true/false
+    private Boolean isExpired;
+
+    private static boolean computeIsExpired(Routine routine) {
+        LocalDate today = LocalDate.now();
+        if (routine.getEndAt() != null && routine.getEndAt().isBefore(today)) return true;
+        if (routine.getRepeatType() == RepeatType.NONE && routine.getStartAt().isBefore(today)) return true;
+        return false;
+    }
 
     // 엔티티 → 응답 DTO 변환 정적 팩토리 (date 없는 조회용 - isCompleted = null)
     public static RoutineResponse from(Routine routine) {
@@ -52,6 +60,7 @@ public class RoutineResponse {
                 .endTime(routine.getEndTime())
                 .startAt(routine.getStartAt())
                 .endAt(routine.getEndAt())
+                .isExpired(computeIsExpired(routine))
                 .build();
     }
 
@@ -78,6 +87,7 @@ public class RoutineResponse {
                 .startAt(routine.getStartAt())
                 .endAt(routine.getEndAt())
                 .isCompleted(isCompleted)
+                .isExpired(computeIsExpired(routine))
                 .build();
     }
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #104 

---

## 작업 내용

- feat: RoutineResponse에 isExpired 필드 추가
- feat: computeIsExpired() 메서드 추가 (endAt 만료 또는 NONE 타입 startAt 경과 시 true)

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> **isExpired 판단 기준**
> 1. `endAt != null && endAt < 오늘` → true (모든 repeatType)
> 2. `repeatType == NONE && startAt < 오늘` → true
> 3. 그 외 → false
>
> endAt 수정 시 별도 동기화 로직 없이 다음 조회부터 자동 반영됨.