### PR TITLE
[Feat] 소셜 로그인 리다이렉트 보안 개선

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/AuthController.java
@@ -84,4 +84,16 @@ public class AuthController {
                 Map.of("isDuplicate", isDuplicate)
         );
     }
+
+    @Operation(summary = "소셜 로그인 코드 토큰 교환")
+    @SecurityRequirements({})
+    @PostMapping("/oauth2/token")
+    public ApiResponse<OAuth2LoginResponse> exchangeOAuth2Code(
+            @RequestBody @Valid OAuth2TokenExchangeRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        String device = httpRequest.getHeader("User-Agent");
+        OAuth2LoginResponse response = authService.exchangeOAuth2Code(request, device);
+        return ApiResponse.ok("소셜 로그인에 성공했습니다.", response);
+    }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/OAuth2LoginResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/OAuth2LoginResponse.java
@@ -1,0 +1,12 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+public record OAuth2LoginResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        boolean isNewUser
+) {
+    public static OAuth2LoginResponse of(String accessToken, String refreshToken, boolean isNewUser) {
+        return new OAuth2LoginResponse(accessToken, refreshToken, "Bearer", isNewUser);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/OAuth2TokenExchangeRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/OAuth2TokenExchangeRequest.java
@@ -1,0 +1,9 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OAuth2TokenExchangeRequest(
+        @NotBlank(message = "OAuth2 로그인 코드가 필요합니다.")
+        String code
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -6,10 +6,14 @@ import com.rutina.rutinabackend.domain.user.dto.*;
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
 import com.rutina.rutinabackend.global.auth.apple.AppleIdentityTokenVerifier;
+import com.rutina.rutinabackend.global.auth.oauth2.OAuth2LoginCode;
+import com.rutina.rutinabackend.global.auth.oauth2.OAuth2LoginCodeStore;
 import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
+import com.rutina.rutinabackend.global.exception.BusinessException;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
 import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
@@ -26,6 +30,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final EmailVerificationService emailVerificationService;
     private final AppleIdentityTokenVerifier appleIdentityTokenVerifier;
+    private final OAuth2LoginCodeStore oAuth2LoginCodeStore;
 
     // ── 회원가입 ───────────────────────────────────────────
     @Transactional
@@ -117,6 +122,27 @@ public class AuthService {
     @Transactional(readOnly = true)
     public boolean checkEmailDuplicate(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public OAuth2LoginResponse exchangeOAuth2Code(OAuth2TokenExchangeRequest request, String device) {
+        OAuth2LoginCode loginCode = oAuth2LoginCodeStore.consume(request.code())
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.UNAUTHORIZED,
+                        "INVALID_OAUTH2_LOGIN_CODE",
+                        "유효하지 않거나 만료된 소셜 로그인 코드입니다."
+                ));
+
+        User user = userRepository.findById(loginCode.userId())
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
+        String tokenDevice = StringUtils.hasText(device) ? device : loginCode.device();
+
+        refreshTokenStore.save(user.getId(), tokenDevice, refreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
+
+        return OAuth2LoginResponse.of(accessToken, refreshToken, loginCode.isNewUser());
     }
 
     @Transactional

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/AuthService.java
@@ -126,6 +126,7 @@ public class AuthService {
 
     @Transactional
     public OAuth2LoginResponse exchangeOAuth2Code(OAuth2TokenExchangeRequest request, String device) {
+        // code는 토큰 발급 전 단계의 임시 교환권이므로 한 번만 소비합니다.
         OAuth2LoginCode loginCode = oAuth2LoginCodeStore.consume(request.code())
                 .orElseThrow(() -> new BusinessException(
                         HttpStatus.UNAUTHORIZED,

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/InMemoryOAuth2LoginCodeStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/InMemoryOAuth2LoginCodeStore.java
@@ -1,0 +1,32 @@
+package com.rutina.rutinabackend.global.auth.oauth2;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Profile("local")
+@Component
+public class InMemoryOAuth2LoginCodeStore implements OAuth2LoginCodeStore {
+
+    private final Map<String, OAuth2LoginCode> values = new ConcurrentHashMap<>();
+    private final Map<String, Long> expiries = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String code, OAuth2LoginCode loginCode, long ttlSeconds) {
+        values.put(code, loginCode);
+        expiries.put(code, System.currentTimeMillis() + ttlSeconds * 1000);
+    }
+
+    @Override
+    public Optional<OAuth2LoginCode> consume(String code) {
+        Long expiry = expiries.remove(code);
+        OAuth2LoginCode value = values.remove(code);
+        if (expiry == null || value == null || System.currentTimeMillis() > expiry) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/InMemoryOAuth2LoginCodeStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/InMemoryOAuth2LoginCodeStore.java
@@ -22,6 +22,7 @@ public class InMemoryOAuth2LoginCodeStore implements OAuth2LoginCodeStore {
 
     @Override
     public Optional<OAuth2LoginCode> consume(String code) {
+        // consume 호출 시 즉시 제거해 같은 code로 토큰을 여러 번 발급받지 못하게 합니다.
         Long expiry = expiries.remove(code);
         OAuth2LoginCode value = values.remove(code);
         if (expiry == null || value == null || System.currentTimeMillis() > expiry) {

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/OAuth2LoginCode.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/OAuth2LoginCode.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.global.auth.oauth2;
+
+public record OAuth2LoginCode(
+        Long userId,
+        boolean isNewUser,
+        String device
+) {
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/OAuth2LoginCodeStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/OAuth2LoginCodeStore.java
@@ -1,0 +1,8 @@
+package com.rutina.rutinabackend.global.auth.oauth2;
+
+import java.util.Optional;
+
+public interface OAuth2LoginCodeStore {
+    void save(String code, OAuth2LoginCode loginCode, long ttlSeconds);
+    Optional<OAuth2LoginCode> consume(String code);
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/RedisOAuth2LoginCodeStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/RedisOAuth2LoginCodeStore.java
@@ -1,0 +1,56 @@
+package com.rutina.rutinabackend.global.auth.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Profile("prod")
+@Component
+@RequiredArgsConstructor
+public class RedisOAuth2LoginCodeStore implements OAuth2LoginCodeStore {
+
+    private static final String CODE_KEY_PREFIX = "oauth2:login-code:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void save(String code, OAuth2LoginCode loginCode, long ttlSeconds) {
+        try {
+            redisTemplate.opsForValue().set(
+                    key(code),
+                    objectMapper.writeValueAsString(loginCode),
+                    ttlSeconds,
+                    TimeUnit.SECONDS
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("OAuth2 로그인 코드 저장에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public Optional<OAuth2LoginCode> consume(String code) {
+        String key = key(code);
+        String value = redisTemplate.opsForValue().get(key);
+        redisTemplate.delete(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(objectMapper.readValue(value, OAuth2LoginCode.class));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String key(String code) {
+        return CODE_KEY_PREFIX + code;
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/RedisOAuth2LoginCodeStore.java
+++ b/src/main/java/com/rutina/rutinabackend/global/auth/oauth2/RedisOAuth2LoginCodeStore.java
@@ -38,6 +38,7 @@ public class RedisOAuth2LoginCodeStore implements OAuth2LoginCodeStore {
     public Optional<OAuth2LoginCode> consume(String code) {
         String key = key(code);
         String value = redisTemplate.opsForValue().get(key);
+        // Redis에서도 조회 직후 삭제해 일회용 code 재사용을 막습니다.
         redisTemplate.delete(key);
         if (value == null) {
             return Optional.empty();

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -2,9 +2,9 @@ package com.rutina.rutinabackend.global.oauth2;
 
 import com.rutina.rutinabackend.domain.user.entity.User;
 import com.rutina.rutinabackend.domain.user.repository.UserRepository;
-import com.rutina.rutinabackend.global.auth.token.RefreshTokenStore;
+import com.rutina.rutinabackend.global.auth.oauth2.OAuth2LoginCode;
+import com.rutina.rutinabackend.global.auth.oauth2.OAuth2LoginCodeStore;
 import com.rutina.rutinabackend.global.exception.ErrorCode;
-import com.rutina.rutinabackend.global.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,14 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Base64;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtProvider jwtProvider;
+    private static final long OAUTH2_LOGIN_CODE_TTL_SECONDS = 120;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final UserRepository userRepository;
-    private final RefreshTokenStore refreshTokenStore;
+    private final OAuth2LoginCodeStore oAuth2LoginCodeStore;
 
     @Value("${oauth2.redirect-url}")
     private String redirectUrl;
@@ -40,25 +44,29 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
         Long userId = Long.valueOf(String.valueOf(oauth2User.getAttributes().get("userId")));
         boolean isNewUser = Boolean.TRUE.equals(oauth2User.getAttributes().get("isNewUser"));
-        String device = request.getHeader("User-Agent"); // 기기별 RefreshToken 관리용
+        String device = request.getHeader("User-Agent");
 
         User user = userRepository.findById(userId)
                 .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
 
-        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
-        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
-
-        // getRefreshTokenExpiry()는 ms 단위, store 인터페이스는 seconds 단위
-        refreshTokenStore.save(user.getId(), device, refreshToken, jwtProvider.getRefreshTokenExpiry() / 1000L);
+        String code = generateLoginCode();
+        oAuth2LoginCodeStore.save(
+                code,
+                new OAuth2LoginCode(user.getId(), isNewUser, device),
+                OAUTH2_LOGIN_CODE_TTL_SECONDS
+        );
 
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken)
-                .queryParam("tokenType", "Bearer")
-                .queryParam("isNewUser", isNewUser)
+                .queryParam("code", code)
                 .build()
                 .toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String generateLoginCode() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/OAuth2SuccessHandler.java
@@ -49,6 +49,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         User user = userRepository.findById(userId)
                 .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
 
+        // Redirect URL에 실제 토큰을 싣지 않기 위해 짧게 살아있는 교환용 code만 전달합니다.
         String code = generateLoginCode();
         oAuth2LoginCodeStore.save(
                 code,


### PR DESCRIPTION
## 관련 이슈

- Closes #107

---

## 작업 내용

- 소셜 로그인 성공 시 `accessToken`, `refreshToken`을 리다이렉트 URL query parameter로 전달하지 않도록 변경했습니다.
- 소셜 로그인 성공 후 2분 TTL의 일회용 `code`를 발급하고, `POST /api/v1/auth/oauth2/token`에서 토큰으로 교환하도록 API를 추가했습니다.
- 일회용 `code`는 1회 사용 시 즉시 만료되도록 처리했습니다.
- `local` 환경은 in-memory 저장소를, `prod` 환경은 Redis 저장소를 사용하도록 분리했습니다.

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 기존 방식은 소셜 로그인 성공 후 `accessToken`, `refreshToken`이 URL query parameter에 포함되었습니다.
>
> 이 경우 토큰이 브라우저 히스토리, 서버/프록시 로그, 에러 수집 로그, Referer 헤더 등에 남을 수 있습니다. 특히 `refreshToken`은 만료 시간이 길어 노출 시 계정 접근 위험이 커질 수 있기 때문에, 배포 앱 기준으로 URL에 직접 포함하지 않는 방식으로 개선했습니다.
>
> 프론트 소셜 로그인 콜백 처리 방식 변경이 필요합니다.
>
> 기존에는 콜백 URL에서 `accessToken`, `refreshToken`, `isNewUser`를 직접 읽었지만, 변경 후에는 콜백 URL의 `code`를 읽어 `POST /api/v1/auth/oauth2/token` API로 토큰을 교환해야 합니다.
>
> 변경 전:
> ```text
> /oauth/callback?accessToken=...&refreshToken=...&tokenType=Bearer&isNewUser=true
> ```
>
> 변경 후:
> ```text
> /oauth/callback?code=...
> ```
>
> 토큰 교환 API 응답의 `data.accessToken`, `data.refreshToken`, `data.isNewUser`를 사용하면 됩니다.