### PR TITLE
[Feat] 과거 AI 응답 기록 출력 API

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/controller/AiController.java
@@ -22,6 +22,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/ai-routines")
 @RequiredArgsConstructor
@@ -116,6 +118,39 @@ public class AiController {
     }
 
     @Operation(
+            summary = "오늘 추천받은 AI 루틴 기록 조회",
+            description = """
+                로그인한 사용자가 오늘 AI에게 추천받은 루틴 기록을 조회합니다.
+
+                이 API는 과거 추천 기록 조회용이므로 AI를 새로 호출하지 않고,
+                하루 3회 추천 횟수도 차감하지 않습니다.
+
+                응답의 각 항목은 AI 루틴 추천 생성 API와 같은
+                recommendationId, categoryId, routines 구조로 반환됩니다.
+                따라서 프론트에서는 추천 생성 결과 화면과 같은 컴포넌트를 재사용할 수 있습니다.
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "오늘 추천받은 AI 루틴 기록 조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            )
+    })
+    @GetMapping("/recommendations/today")
+    public ApiResponse<List<AiRoutineRecommendResponse>> getTodayRecommendations(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return ApiResponse.ok(
+                "오늘 추천받은 루틴 조회에 성공했습니다.",
+                aiService.getTodayRecommendations(userDetails)
+        );
+    }
+
+    @Operation(
             summary = "선택한 AI 추천 루틴 추가",
             description = """
                     AI 추천 결과 중 사용자가 선택한 루틴만 실제 routines 테이블에 추가합니다.
@@ -148,6 +183,8 @@ public class AiController {
                     description = "AI 추천 기록을 찾을 수 없음"
             )
     })
+
+
     @PostMapping("/{recommendationId}/add")
     public ApiResponse<AiRoutineAddResponse> addRecommendedRoutines(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/repository/AiLogRepository.java
@@ -27,6 +27,22 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
             OffsetDateTime end
     );
 
+    @Query("""
+        SELECT a
+        FROM AiLog a
+        WHERE a.user.id = :userId
+          AND a.requestType = :requestType
+          AND a.createdAt >= :start
+          AND a.createdAt < :end
+        ORDER BY a.createdAt DESC
+    """)
+        List<AiLog> findTodayRecommendations(
+                @Param("userId") Long userId,
+                @Param("requestType") String requestType,
+                @Param("start") OffsetDateTime start,
+                @Param("end") OffsetDateTime end
+        );
+
     // 루틴 삭제 전 먼저 호출 필수
     @Modifying
     @Query("UPDATE AiLog a SET a.routine = null WHERE a.routine.id IN :routineIds")
@@ -36,4 +52,5 @@ public interface AiLogRepository extends JpaRepository<AiLog, Long> {
     @Modifying
     @Query("UPDATE AiLog a SET a.user = null WHERE a.user.id = :userId")
     void anonymizeByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/ailog/service/AiService.java
@@ -388,6 +388,50 @@ public class AiService {
     }
 
     /**
+     * 오늘 AI가 추천했던 루틴 기록 조회
+     *
+     * 추천 생성 API와 같은 AiRoutineRecommendResponse 형태로 반환한다.
+     * 그래서 프론트는 새 추천 결과 화면과 과거 추천 기록 화면에서 같은 컴포넌트를 재사용할 수 있다.
+     */
+    @Transactional(readOnly = true)
+    public List<AiRoutineRecommendResponse> getTodayRecommendations(UserDetails userDetails) {
+        User user = getLoginUser(userDetails);
+
+        LocalDate today = LocalDate.now(KOREA_ZONE);
+
+        OffsetDateTime startOfToday = today
+                .atStartOfDay(KOREA_ZONE)
+                .toOffsetDateTime();
+
+        OffsetDateTime startOfTomorrow = today
+                .plusDays(1)
+                .atStartOfDay(KOREA_ZONE)
+                .toOffsetDateTime();
+
+        List<AiLog> logs = aiLogRepository.findTodayRecommendations(
+                user.getId(),
+                REQUEST_TYPE_ROUTINE_RECOMMEND,
+                startOfToday,
+                startOfTomorrow
+        );
+
+        return logs.stream()
+                .map(this::toRecommendResponse)
+                .toList();
+    }
+
+    private AiRoutineRecommendResponse toRecommendResponse(AiLog aiLog) {
+        AiRoutinePromptLog promptLog = fromJson(aiLog.getPrompt(), AiRoutinePromptLog.class);
+        AiRoutineRecommendResult result = fromJson(aiLog.getResponse(), AiRoutineRecommendResult.class);
+
+        return new AiRoutineRecommendResponse(
+                aiLog.getId(),
+                promptLog.categoryId(),
+                result.routines()
+        );
+    }
+
+    /**
      * AI 추천 결과 정리
      *
      * 보정 내용:


### PR DESCRIPTION
## 관련 이슈

- Closes #106 

---

## 작업 내용

- 오늘 추천받은 AI 루틴 기록 조회 API 추가
- AI 추천 생성 응답과 동일한 `AiRoutineRecommendResponse` 형태로 과거 추천 기록 반환
- `AiLog`의 `prompt`, `response` JSON을 파싱하여 `recommendationId`, `categoryId`, `routines` 재구성
- 오늘 00:00부터 내일 00:00 전까지의 AI 추천 기록만 조회하도록 처리
- 조회 API는 AI를 새로 호출하지 않아 하루 추천 횟수 제한에 영향 없도록 구현

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 조회 API는 기존 AI 추천 결과 화면과 같은 프론트 컴포넌트를 재사용할 수 있도록 추천 생성 API와 동일한 응답 구조를 사용