### PR TITLE
[Feat] 루틴 목록/단건 조회 isCompleted 조건 정의 및 적용

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineResponse.java
@@ -28,17 +28,9 @@ public class RoutineResponse {
     private LocalTime endTime;
     private LocalDate startAt;
     private LocalDate endAt;
-    private Boolean isCompleted;        // date 없는 조회 시 null, date 있는 조회 시 true/false
-    private Boolean isExpired;
+    private Boolean isCompleted;
 
-    private static boolean computeIsExpired(Routine routine) {
-        LocalDate today = LocalDate.now();
-        if (routine.getEndAt() != null && routine.getEndAt().isBefore(today)) return true;
-        if (routine.getRepeatType() == RepeatType.NONE && routine.getStartAt().isBefore(today)) return true;
-        return false;
-    }
-
-    // 엔티티 → 응답 DTO 변환 정적 팩토리 (date 없는 조회용 - isCompleted = null)
+    // 엔티티 → 응답 DTO 변환 정적 팩토리 (isCompleted 없는 단건 조회용)
     public static RoutineResponse from(Routine routine) {
         List<DayOfWeek> repeatDays = routine.getRepeatDays() == null
                 ? Collections.emptyList()
@@ -60,11 +52,10 @@ public class RoutineResponse {
                 .endTime(routine.getEndTime())
                 .startAt(routine.getStartAt())
                 .endAt(routine.getEndAt())
-                .isExpired(computeIsExpired(routine))
                 .build();
     }
 
-    // 엔티티 → 응답 DTO 변환 정적 팩토리 (date 있는 조회용 - isCompleted 값 포함)
+    // 엔티티 → 응답 DTO 변환 정적 팩토리 (isCompleted 포함)
     public static RoutineResponse from(Routine routine, boolean isCompleted) {
         List<DayOfWeek> repeatDays = routine.getRepeatDays() == null
                 ? Collections.emptyList()
@@ -87,7 +78,6 @@ public class RoutineResponse {
                 .startAt(routine.getStartAt())
                 .endAt(routine.getEndAt())
                 .isCompleted(isCompleted)
-                .isExpired(computeIsExpired(routine))
                 .build();
     }
 }

--- a/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/service/RoutineService.java
@@ -95,10 +95,11 @@ public class RoutineService {
     // date가 있으면 2단계 필터링:
     //   1단계: DB 쿼리로 유효 기간(start_at <= date <= end_at) 내 루틴 추출
     //   2단계: isActiveOnDate()로 repeat_type별 날짜 계산 필터링
-    // date가 있으면 DailyTarget 일괄 조회 후 isCompleted 포함 응답 (N+1 방지)
+    // date가 없으면 오늘 기준으로 isCompleted 계산 (null 방지)
     public List<RoutineResponse> getRoutines(Long userId, Long categoryId, LocalDate date) {
-        List<Routine> routines;
+        LocalDate targetDate = date != null ? date : LocalDate.now();
 
+        List<Routine> routines;
         if (date == null && categoryId == null) {
             routines = routineRepository.findByUserId(userId);
         } else if (date == null) {
@@ -115,26 +116,26 @@ public class RoutineService {
                     .collect(Collectors.toList());
         }
 
-        if (date == null) {
-            return routines.stream()
-                    .map(RoutineResponse::from)
-                    .collect(Collectors.toList());
-        }
-
         List<Long> routineIds = routines.stream().map(Routine::getId).collect(Collectors.toList());
         Map<Long, Boolean> completedMap = dailyTargetRepository
-                .findByRoutineIdInAndTargetDate(routineIds, date)
+                .findByRoutineIdInAndTargetDate(routineIds, targetDate)
                 .stream()
                 .collect(Collectors.toMap(dt -> dt.getRoutine().getId(), DailyTarget::getIsCompleted));
 
         return routines.stream()
-                .map(r -> RoutineResponse.from(r, completedMap.getOrDefault(r.getId(), false)))
+                .map(r -> RoutineResponse.from(r, computeIsCompleted(r, targetDate, completedMap)))
                 .collect(Collectors.toList());
     }
 
     // ── 루틴 단건 조회 ─────────────────────────────────────────────
     public RoutineResponse getRoutine(Long userId, Long routineId) {
-        return RoutineResponse.from(findRoutine(userId, routineId));
+        Routine routine = findRoutine(userId, routineId);
+        LocalDate today = LocalDate.now();
+        Map<Long, Boolean> completedMap = dailyTargetRepository
+                .findByRoutineIdInAndTargetDate(List.of(routine.getId()), today)
+                .stream()
+                .collect(Collectors.toMap(dt -> dt.getRoutine().getId(), DailyTarget::getIsCompleted));
+        return RoutineResponse.from(routine, computeIsCompleted(routine, today, completedMap));
     }
 
     // ── 타임테이블 조회 ────────────────────────────────────────────
@@ -408,6 +409,44 @@ public class RoutineService {
         return days.stream()
                 .map(Enum::name)
                 .collect(Collectors.joining(","));
+    }
+
+    // ── isCompleted 계산 ───────────────────────────────────────────
+    // 1. endAt < 오늘 → 기간 만료, 토글 무관 true
+    // 2. NONE 타입 → 오늘이 startAt이고 오늘 DailyTarget 완료
+    // 3. endAt 있음 → 오늘이 마지막 실제 반복일이고 오늘 DailyTarget 완료
+    // 나머지 → false
+    private boolean computeIsCompleted(Routine routine, LocalDate today, Map<Long, Boolean> completedMap) {
+        boolean todayCompleted = completedMap.getOrDefault(routine.getId(), false);
+
+        if (routine.getEndAt() != null && routine.getEndAt().isBefore(today)) {
+            return true;
+        }
+
+        if (routine.getRepeatType() == RepeatType.NONE) {
+            return routine.getStartAt().equals(today) && todayCompleted;
+        }
+
+        if (routine.getEndAt() != null) {
+            LocalDate lastRepeatDate = findLastRepeatDate(routine);
+            if (lastRepeatDate != null && lastRepeatDate.equals(today)) {
+                return todayCompleted;
+            }
+        }
+
+        return false;
+    }
+
+    // endAt부터 startAt까지 역탐색하며 isActiveOnDate()가 true인 첫 번째 날짜 반환
+    private LocalDate findLastRepeatDate(Routine routine) {
+        LocalDate cursor = routine.getEndAt();
+        while (!cursor.isBefore(routine.getStartAt())) {
+            if (isActiveOnDate(routine, cursor)) {
+                return cursor;
+            }
+            cursor = cursor.minusDays(1);
+        }
+        return null;
     }
 
     // ── 날짜별 활성 여부 판단 ──────────────────────────────────────


### PR DESCRIPTION
## 관련 이슈

- Closes #110 

---

## 작업 내용

- refactor: RoutineResponse에서 isExpired 필드 제거 (isCompleted로 통합)
- feat: 루틴 목록/단건 조회 시 isCompleted 오늘 날짜 기준 계산 적용
- feat: computeIsCompleted() 추가 — 기간 만료/마지막 반복일 완료/NONE 당일 완료 조건 처리
- feat: findLastRepeatDate() 추가 — endAt 기준 역탐색으로 마지막 실제 반복일 계산

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] API 응답 형식 확인

---

## 참고사항

> **isCompleted: true 조건**
> 1. `endAt != null && endAt < 오늘` → 기간 만료, 토글 여부 무관
> 2. `repeatType == NONE && startAt == 오늘 && 오늘 DailyTarget 완료`
> 3. `endAt != null && 오늘 == 마지막 실제 반복일 && 오늘 DailyTarget 완료`
>
> date 없는 전체/카테고리별/단건 조회 모두 LocalDate.now() 기준으로 계산.
> endAt 없는 무한반복 루틴은 항상 false.