### PR TITLE
[Feat] 히트맵 조회 응답에 루틴 startAt, endAt 필드 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/routine/dto/RoutineHeatmapResponse.java
@@ -2,11 +2,14 @@ package com.rutina.rutinabackend.domain.routine.dto;
 
 import com.rutina.rutinabackend.domain.routine.entity.Routine;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 public record RoutineHeatmapResponse(
         Long routineId,
         String title,
+        LocalDate startAt,
+        LocalDate endAt,
         RoutineHeatmapCategoryResponse category,
         Map<String, Boolean> completed
 ) {
@@ -15,6 +18,8 @@ public record RoutineHeatmapResponse(
         return new RoutineHeatmapResponse(
                 routine.getId(),
                 routine.getTitle(),
+                routine.getStartAt(),
+                routine.getEndAt(),
                 RoutineHeatmapCategoryResponse.from(routine.getCategory()),
                 completed
         );


### PR DESCRIPTION
## 관련 이슈

- Closes #114 

---

## 작업 내용

- `RoutineHeatmapResponse`에 `startAt`, `endAt` 필드 추가
- `from()` 팩토리 메서드에서 `Routine` 엔티티의 해당 값 매핑

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] API 응답 형식 확인

---

## 참고사항

> `endAt`은 무기한 루틴의 경우 `null`로 응답됩니다. 프론트엔드에서 null 처리가 필요합니다.