### PR TITLE
[Feat] 토큰 기반 신규 유저(온보딩 미완료) 여부 확인 API 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.rutina.rutinabackend.domain.user.controller;
 
+import com.rutina.rutinabackend.domain.user.dto.NewUserStatusResponse;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
 import com.rutina.rutinabackend.domain.user.dto.PasswordChangeRequest;
@@ -30,6 +31,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @Operation(
+            summary = "신규 유저 여부 확인",
+            description = "액세스 토큰으로 인증된 유저의 온보딩 완료 여부를 확인합니다. 프로필(나이/성별/직업)이 하나라도 비어 있으면 신규 유저로 판단합니다."
+    )
+    @GetMapping("/me/new-status")
+    public ApiResponse<NewUserStatusResponse> getNewUserStatus(@AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        NewUserStatusResponse response = userService.getNewUserStatus(userId);
+        return ApiResponse.ok("신규 유저 여부를 확인했습니다.", response);
+    }
 
     @Operation(summary = "내 정보 조회")
     @GetMapping("/me")

--- a/src/main/java/com/rutina/rutinabackend/domain/user/dto/NewUserStatusResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/dto/NewUserStatusResponse.java
@@ -1,0 +1,9 @@
+package com.rutina.rutinabackend.domain.user.dto;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+
+public record NewUserStatusResponse(boolean isNewUser) {
+    public static NewUserStatusResponse from(User user) {
+        return new NewUserStatusResponse(user.isOnboardingIncomplete());
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/entity/User.java
@@ -97,6 +97,11 @@ public class User {
         this.updatedAt = OffsetDateTime.now();
     }
 
+    // 프로필(나이/성별/직업)이 하나라도 비어 있으면 온보딩 미완료(신규 유저)로 판단
+    public boolean isOnboardingIncomplete() {
+        return this.age == null || this.gender == null || this.job == null;
+    }
+
     // 실제 레코드 삭제가 아닌 deleted_at 시각 기록
     public void softDelete() {
         this.deletedAt = OffsetDateTime.now();

--- a/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.rutina.rutinabackend.domain.ailog.repository.AiLogRepository;
 import com.rutina.rutinabackend.domain.category.repository.CategoryRepository;
 import com.rutina.rutinabackend.domain.email.service.EmailVerificationService;
 import com.rutina.rutinabackend.domain.routine.repository.RoutineRepository;
+import com.rutina.rutinabackend.domain.user.dto.NewUserStatusResponse;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateRequest;
 import com.rutina.rutinabackend.domain.user.dto.NicknameUpdateResponse;
 import com.rutina.rutinabackend.domain.user.dto.PasswordChangeRequest;
@@ -37,6 +38,13 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
         return UserResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public NewUserStatusResponse getNewUserStatus(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
+        return NewUserStatusResponse.from(user);
     }
 
     @Transactional

--- a/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/rutina/rutinabackend/global/oauth2/CustomOAuth2UserService.java
@@ -71,7 +71,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         }
 
         // 프로필 완성 여부 확인
-        boolean isNewUser = user.getAge() == null || user.getGender() == null || user.getJob() == null;
+        boolean isNewUser = user.isOnboardingIncomplete();
 
         Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
         attributes.put("userId", user.getId());


### PR DESCRIPTION
## 관련 이슈

- Closes #116 

---

## 작업 내용

- `User.isOnboardingIncomplete()` 메서드 추가 — 신규 유저 판정 조건(`age/gender/job` 중 하나라도 null)을 엔티티로 일원화, `CustomOAuth2UserService` 인라인 조건 교체
- `NewUserStatusResponse` DTO 추가
- `UserService.getNewUserStatus()` 추가
- `GET /api/v1/users/me/new-status` 엔드포인트 추가

---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] API 응답 형식 확인

---

## 참고사항

> 소셜 로그인 code 교환 응답의 `isNewUser`는 최초 1회만 전달되므로, 앱 재진입 시 온보딩 완료 여부를 재확인할 수단이 없었음. 해당 API로 토큰만 있으면 언제든 확인 가능.
> 
> 판정 기준(`age/gender/job` 중 하나라도 null → 신규)은 기존 `CustomOAuth2UserService`와 동일하며, 이번 작업으로 `User.isOnboardingIncomplete()` 단일 출처로 통합됨.