### PR TITLE
[Feat] Todo 기능 추가

### DIFF
--- a/src/main/java/com/rutina/rutinabackend/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/controller/TodoController.java
@@ -1,0 +1,100 @@
+package com.rutina.rutinabackend.domain.todo.controller;
+
+import com.rutina.rutinabackend.domain.todo.dto.*;
+import com.rutina.rutinabackend.domain.todo.service.TodoService;
+import com.rutina.rutinabackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/todos")
+@Tag(name = "Todo", description = "캘린더 Todo API")
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @Operation(summary = "Todo 생성", description = "선택한 날짜에 Todo를 생성합니다. 시간은 선택 입력이며 내용은 최대 30자까지 입력할 수 있습니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<TodoResponse> createTodo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TodoCreateRequest request
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.created("Todo가 생성되었습니다.", todoService.createTodo(userId, request));
+    }
+
+    @Operation(summary = "날짜별 Todo 조회", description = "특정 날짜에 등록된 Todo 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponse<List<TodoResponse>> getTodosByDate(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.ok("Todo 목록 조회에 성공했습니다.", todoService.getTodosByDate(userId, date));
+    }
+
+    @Operation(summary = "오늘 Todo 조회", description = "오늘 날짜에 등록된 Todo 목록을 조회합니다.")
+    @GetMapping("/today")
+    public ApiResponse<List<TodoResponse>> getTodayTodos(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.ok("오늘 Todo 목록 조회에 성공했습니다.", todoService.getTodayTodos(userId));
+    }
+
+    @Operation(summary = "월별 Todo 조회", description = "캘린더 표시를 위해 특정 연월에 등록된 Todo 목록을 조회합니다.")
+    @GetMapping("/month")
+    public ApiResponse<List<TodoResponse>> getTodosByMonth(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.ok("월별 Todo 목록 조회에 성공했습니다.", todoService.getTodosByMonth(userId, year, month));
+    }
+
+    @Operation(summary = "Todo 수정", description = "Todo의 날짜, 시간, 내용을 수정합니다.")
+    @PutMapping("/{todoId}")
+    public ApiResponse<TodoResponse> updateTodo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoUpdateRequest request
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.ok("Todo가 수정되었습니다.", todoService.updateTodo(userId, todoId, request));
+    }
+
+    @Operation(summary = "Todo 완료 상태 변경", description = "Todo의 완료 여부를 체크 또는 해제합니다.")
+    @PatchMapping("/{todoId}/completed")
+    public ApiResponse<TodoResponse> updateCompleted(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoCompletedRequest request
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ApiResponse.ok("Todo 완료 상태가 변경되었습니다.", todoService.updateCompleted(userId, todoId, request));
+    }
+
+    @Operation(summary = "Todo 삭제", description = "등록된 Todo를 삭제합니다.")
+    @DeleteMapping("/{todoId}")
+    public ApiResponse<Void> deleteTodo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long todoId
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        todoService.deleteTodo(userId, todoId);
+        return ApiResponse.ok("Todo가 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoCompletedRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoCompletedRequest.java
@@ -1,0 +1,13 @@
+package com.rutina.rutinabackend.domain.todo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoCompletedRequest {
+
+    @NotNull(message = "완료 여부는 필수입니다.")
+    private Boolean completed;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoCreateRequest.java
@@ -1,0 +1,24 @@
+package com.rutina.rutinabackend.domain.todo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class TodoCreateRequest {
+
+    @NotNull(message = "날짜는 필수입니다.")
+    private LocalDate todoDate;
+
+    private LocalTime todoTime;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 30, message = "내용은 최대 30자까지 입력할 수 있습니다.")
+    private String content;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoResponse.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoResponse.java
@@ -1,0 +1,29 @@
+package com.rutina.rutinabackend.domain.todo.dto;
+
+import com.rutina.rutinabackend.domain.todo.entity.Todo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class TodoResponse {
+
+    private Long id;
+    private LocalDate todoDate;
+    private LocalTime todoTime;
+    private String content;
+    private Boolean completed;
+
+    public static TodoResponse from(Todo todo) {
+        return TodoResponse.builder()
+                .id(todo.getId())
+                .todoDate(todo.getTodoDate())
+                .todoTime(todo.getTodoTime())
+                .content(todo.getContent())
+                .completed(todo.getCompleted())
+                .build();
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/dto/TodoUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.rutina.rutinabackend.domain.todo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class TodoUpdateRequest {
+
+    @NotNull(message = "날짜는 필수입니다.")
+    private LocalDate todoDate;
+
+    private LocalTime todoTime;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 30, message = "내용은 최대 30자까지 입력할 수 있습니다.")
+    private String content;
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/entity/Todo.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/entity/Todo.java
@@ -1,0 +1,70 @@
+package com.rutina.rutinabackend.domain.todo.entity;
+
+import com.rutina.rutinabackend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "todos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "todo_date", nullable = false)
+    private LocalDate todoDate;
+
+    @Column(name = "todo_time")
+    private LocalTime todoTime;
+
+    @Column(nullable = false, length = 30)
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean completed;
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMPTZ DEFAULT now()")
+    private OffsetDateTime updatedAt;
+
+    public static Todo create(User user, LocalDate todoDate, LocalTime todoTime, String content) {
+        Todo todo = new Todo();
+        todo.user = user;
+        todo.todoDate = todoDate;
+        todo.todoTime = todoTime;
+        todo.content = content;
+        todo.completed = false;
+        todo.createdAt = OffsetDateTime.now();
+        todo.updatedAt = OffsetDateTime.now();
+        return todo;
+    }
+
+    public void update(LocalDate todoDate, LocalTime todoTime, String content) {
+        this.todoDate = todoDate;
+        this.todoTime = todoTime;
+        this.content = content;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void updateCompleted(Boolean completed) {
+        this.completed = completed;
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/repository/TodoRepository.java
@@ -1,0 +1,21 @@
+package com.rutina.rutinabackend.domain.todo.repository;
+
+import com.rutina.rutinabackend.domain.todo.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+    Optional<Todo> findByIdAndUser_Id(Long todoId, Long userId);
+
+    List<Todo> findAllByUser_IdAndTodoDateOrderByTodoTimeAscIdAsc(Long userId, LocalDate todoDate);
+
+    List<Todo> findAllByUser_IdAndTodoDateBetweenOrderByTodoDateAscTodoTimeAscIdAsc(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+}

--- a/src/main/java/com/rutina/rutinabackend/domain/todo/sevice/TodoService.java
+++ b/src/main/java/com/rutina/rutinabackend/domain/todo/sevice/TodoService.java
@@ -1,0 +1,108 @@
+package com.rutina.rutinabackend.domain.todo.service;
+
+import com.rutina.rutinabackend.domain.todo.dto.*;
+import com.rutina.rutinabackend.domain.todo.entity.Todo;
+import com.rutina.rutinabackend.domain.todo.repository.TodoRepository;
+import com.rutina.rutinabackend.domain.user.entity.User;
+import com.rutina.rutinabackend.domain.user.repository.UserRepository;
+import com.rutina.rutinabackend.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TodoResponse createTodo(Long userId, TodoCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "USER_404", "사용자를 찾을 수 없습니다."));
+
+        Todo todo = Todo.create(
+                user,
+                request.getTodoDate(),
+                request.getTodoTime(),
+                request.getContent().trim()
+        );
+
+        return TodoResponse.from(todoRepository.save(todo));
+    }
+
+    public List<TodoResponse> getTodosByDate(Long userId, LocalDate date) {
+        return sortTodos(todoRepository.findAllByUser_IdAndTodoDateOrderByTodoTimeAscIdAsc(userId, date));
+    }
+
+    public List<TodoResponse> getTodayTodos(Long userId) {
+        return getTodosByDate(userId, LocalDate.now());
+    }
+
+    public List<TodoResponse> getTodosByMonth(Long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+
+        List<Todo> todos = todoRepository.findAllByUser_IdAndTodoDateBetweenOrderByTodoDateAscTodoTimeAscIdAsc(
+                userId,
+                yearMonth.atDay(1),
+                yearMonth.atEndOfMonth()
+        );
+
+        return sortTodos(todos);
+    }
+
+    @Transactional
+    public TodoResponse updateTodo(Long userId, Long todoId, TodoUpdateRequest request) {
+        Todo todo = findTodo(userId, todoId);
+
+        todo.update(
+                request.getTodoDate(),
+                request.getTodoTime(),
+                request.getContent().trim()
+        );
+
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public TodoResponse updateCompleted(Long userId, Long todoId, TodoCompletedRequest request) {
+        Todo todo = findTodo(userId, todoId);
+        todo.updateCompleted(request.getCompleted());
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public void deleteTodo(Long userId, Long todoId) {
+        Todo todo = findTodo(userId, todoId);
+        todoRepository.delete(todo);
+    }
+
+    private Todo findTodo(Long userId, Long todoId) {
+        return todoRepository.findByIdAndUser_Id(todoId, userId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "TODO_404", "Todo를 찾을 수 없습니다."));
+    }
+
+    private List<TodoResponse> sortTodos(List<Todo> todos) {
+        return todos.stream()
+                .sorted(
+                        Comparator
+                                .comparing((Todo todo) -> todo.getTodoTime() == null)
+                                .thenComparing(Todo::getTodoDate)
+                                .thenComparing(
+                                        Todo::getTodoTime,
+                                        Comparator.nullsLast(Comparator.naturalOrder())
+                                )
+                                .thenComparing(Todo::getId)
+                )
+                .map(TodoResponse::from)
+                .toList();
+    }
+}

--- a/src/main/resources/db/migration/V12__create_todos.sql
+++ b/src/main/resources/db/migration/V12__create_todos.sql
@@ -1,0 +1,17 @@
+CREATE TABLE todos (
+                       id BIGSERIAL PRIMARY KEY,
+                       user_id BIGINT NOT NULL,
+                       todo_date DATE NOT NULL,
+                       todo_time TIME,
+                       content VARCHAR(30) NOT NULL,
+                       completed BOOLEAN NOT NULL DEFAULT FALSE,
+                       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                       updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+                       CONSTRAINT fk_todos_user
+                           FOREIGN KEY (user_id)
+                               REFERENCES users(id)
+                               ON DELETE CASCADE
+);
+
+CREATE INDEX idx_todos_user_date ON todos(user_id, todo_date);


### PR DESCRIPTION
## 관련 이슈

- Closes #127

---

## 작업 내용
- 캘린더 기반 Todo 기능 추가
- Todo 생성, 날짜별 조회, 월별 조회, 오늘 조회 API 구현
- Todo 수정, 완료 상태 변경, 삭제 API 구현
- Todo 내용 30자 제한 및 필수값 검증 추가
- 사용자별 Todo 접근 제어 적용
- Swagger API 명세 추가
- todos 테이블 생성 마이그레이션 추가
-
---

## 테스트 체크리스트

- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인
- [x] API 응답 형식 확인

---

## 참고사항

> 리뷰어가 알아야 할 내용이나 특이사항을 적어주세요.